### PR TITLE
TextureAlign, Transparent

### DIFF
--- a/Chisel.DataStructures/MapObjects/Entity.cs
+++ b/Chisel.DataStructures/MapObjects/Entity.cs
@@ -79,8 +79,11 @@ namespace Chisel.DataStructures.MapObjects
         {
             if (GameData == null && !Children.Any())
             {
-                var sub = new Coordinate(-16, -16, -16);
-                var add = new Coordinate(16, 16, 16);
+                //var sub = new Coordinate(-16, -16, -16);
+                //var add = new Coordinate(16, 16, 16);
+                //NOTE(SVK):Smaller entity boxes.
+                var sub = new Coordinate(-8, -8, -8);
+                var add = new Coordinate(8, 8, 8);
                 BoundingBox = new Box(Origin + sub, Origin + add);
             }
             else if (MetaData.Has<Box>("BoundingBox"))
@@ -93,8 +96,11 @@ namespace Chisel.DataStructures.MapObjects
             }
             else if (GameData != null && GameData.ClassType == ClassType.Point)
             {
-                var sub = new Coordinate(-16, -16, -16);
-                var add = new Coordinate(16, 16, 16);
+                //var sub = new Coordinate(-16, -16, -16);
+                //var add = new Coordinate(16, 16, 16);
+                //NOTE(SVK):Smaller entity boxes.
+                var sub = new Coordinate(-8, -8, -8);
+                var add = new Coordinate(8, 8, 8);
                 var behav = GameData.Behaviours.SingleOrDefault(x => x.Name == "size");
                 if (behav != null && behav.Values.Count >= 6)
                 {

--- a/Chisel.DataStructures/MapObjects/Face.cs
+++ b/Chisel.DataStructures/MapObjects/Face.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using Chisel.DataStructures.Geometric;
 using Chisel.DataStructures.Transformations;
 using Chisel.Extensions;
+using System.Diagnostics;
 
 namespace Chisel.DataStructures.MapObjects
 {
@@ -62,9 +63,9 @@ namespace Chisel.DataStructures.MapObjects
             ID = info.GetInt64("ID");
             Flags = (FaceFlags)info.GetInt32("Flags");
             Colour = Color.FromArgb(info.GetInt32("Colour"));
-            Plane = (Plane) info.GetValue("Plane", typeof (Plane));
-            Texture = (TextureReference) info.GetValue("Texture", typeof (TextureReference));
-            Vertices = ((Vertex[]) info.GetValue("Vertices", typeof (Vertex[]))).ToList();
+            Plane = (Plane)info.GetValue("Plane", typeof(Plane));
+            Texture = (TextureReference)info.GetValue("Texture", typeof(TextureReference));
+            Vertices = ((Vertex[])info.GetValue("Vertices", typeof(Vertex[]))).ToList();
             Vertices.ForEach(x => x.Parent = this);
         }
 
@@ -81,17 +82,17 @@ namespace Chisel.DataStructures.MapObjects
         public virtual Face Copy(IDGenerator generator)
         {
             var f = new Face(generator.GetNextFaceID())
-                        {
-                            Flags = Flags,
-                            Plane = Plane.Clone(),
-                            Colour = Colour,
-                            IsSelected = IsSelected,
-                            IsHidden = IsHidden,
-                            Opacity = Opacity,
-                            Texture = Texture.Clone(),
-                            Parent = Parent,
-                            BoundingBox = BoundingBox.Clone()
-                        };
+            {
+                Flags = Flags,
+                Plane = Plane.Clone(),
+                Colour = Colour,
+                IsSelected = IsSelected,
+                IsHidden = IsHidden,
+                Opacity = Opacity,
+                Texture = Texture.Clone(),
+                Parent = Parent,
+                BoundingBox = BoundingBox.Clone()
+            };
             foreach (var v in Vertices.Select(x => x.Clone()))
             {
                 v.Parent = f;
@@ -206,6 +207,10 @@ namespace Chisel.DataStructures.MapObjects
 
         public virtual void CalculateTextureCoordinates(bool minimizeShiftValues)
         {
+            if (this.ID == 1054)
+            {
+                this.Opacity = this.Opacity;
+            }
             if (minimizeShiftValues) MinimiseTextureShiftValues();
             Vertices.ForEach(c => c.TextureU = c.TextureV = 0);
 
@@ -225,6 +230,10 @@ namespace Chisel.DataStructures.MapObjects
             }
         }
 
+        /* NOTE(SVK):Texture Align to match face.cpp in RFedit */
+        /*
+        
+        
         public void AlignTextureToWorld()
         {
             // Set the U and V axes to match the X, Y, or Z axes
@@ -260,6 +269,7 @@ namespace Chisel.DataStructures.MapObjects
 
             CalculateTextureCoordinates(true);
         }
+        
 
         public bool IsTextureAlignedToWorld()
         {
@@ -272,6 +282,174 @@ namespace Chisel.DataStructures.MapObjects
         {
             var cp = Texture.UAxis.Cross(Texture.VAxis).Normalise();
             return cp.EquivalentTo(Plane.Normal, 0.01m) || cp.EquivalentTo(-Plane.Normal, 0.01m);
+        }
+        */
+
+        private UInt32 DetermineAxis(Coordinate v)
+        {
+            UInt32 Result = 0;
+            float x, y, z;
+            //NOTE(SVK): used the RF xyz coords here
+            //Round is a hack to avoid precision issues with better datatypes used in code.
+            //TODO(SVK): Calc a plane normal that matches in precision RF
+            x = (float)Math.Round(Math.Abs(v.X), 7);
+            y = (float)Math.Round(Math.Abs(v.Z), 7);
+            z = (float)Math.Round(Math.Abs(v.Y), 7);
+
+            if (y > x)
+            {
+                if (z > y) { Result = 2; }
+                else { Result = 1; }
+            }
+            else if (z > x) { Result = 2; }
+            return (Result);
+        }
+
+        public void AlignTextureToWorld()
+        {
+            float cosA, sinA, angle = (((float)-Texture.Rotation * (float)3.14159265358979323846f) / (float)180.0f);
+            sinA = (float)Math.Sin(angle);
+            cosA = (float)Math.Cos(angle);
+            UInt32 Axis = DetermineAxis(this.Plane.Normal);
+
+            //Note Y is Z and Z is Y
+            switch (Axis)
+            {
+                case 0:
+                    Texture.UAxis = new Coordinate(0, (decimal)-cosA, (decimal)sinA);
+                    Texture.VAxis = new Coordinate(0, (decimal)-sinA, (decimal)-cosA);
+                    break;
+                case 1:
+                    Texture.UAxis = new Coordinate((decimal)cosA, (decimal)-sinA, 0);
+                    Texture.VAxis = new Coordinate((decimal)-sinA, (decimal)-cosA, 0);
+                    break;
+                case 2:
+                    Texture.UAxis = new Coordinate((decimal)cosA, 0, (decimal)sinA);
+                    Texture.VAxis = new Coordinate((decimal)sinA, 0, (decimal)-cosA);
+                    break;
+            }
+            CalculateTextureCoordinates(false);
+
+        }
+
+        public void AlignTextureToFace()
+        {
+            ////TODO(SVK): Rewrite this entire function:
+            ////direct translation from face.cpp need to optimize, im sure this is slow.
+            //float d1, d2, theta, cosV, cosA, sinA, angle = (((float)Texture.Rotation * (float)3.14159265358979323846f) / (float)180.0f);
+            //Coordinate axis = new Coordinate(0, 0, 0), d = new Coordinate(0, 0, 1), pN = new Coordinate(Math.Abs(this.Plane.Normal.X),
+            //                                                                                       Math.Abs(this.Plane.Normal.Y),
+            //                                                                                       Math.Abs(this.Plane.Normal.Z));
+            //pN.X = Math.Abs(pN.X);
+            //pN.Y = Math.Abs(pN.Y);
+            //pN.Z = Math.Abs(pN.Z);
+            ////Inverse of normal
+            //if (pN.X > pN.Y && pN.X > pN.Z && pN.X > 0) { pN *= -1; }
+            //else if (pN.X > pN.Y && pN.X <= pN.Z && pN.Z > 0) { pN *= -1; }
+            //else if (pN.X <= pN.Y && pN.Y > pN.Z && pN.Y > 0) { pN *= -1; }
+            //else if (pN.X <= pN.Y && pN.Y <= pN.Z && pN.Z > 0) { pN *= -1; }
+            ////CrossProduct
+            //axis.X = d.Y * pN.Z - d.Z * pN.Y;
+            //axis.Y = d.Z * pN.X - d.X * pN.Z;
+            //axis.Z = d.X * pN.Y - d.Y * pN.X;
+            ////DotProduct
+            //cosV = (float)(d.X * pN.X + d.Y * pN.Y + d.Z * pN.Z);
+            //if (cosV > 1.0f) cosV = 1.0f;
+            //theta = (float)Math.Acos(cosV);
+            ////Normalize
+            //d1 = (float)axis.X * (float)axis.X;
+            //d1 += (float)axis.Y * (float)axis.Y;
+            //d1 += (float)axis.Z * (float)axis.Z;
+            //d1 = (float)Math.Sqrt(d1);
+            //d2 = d1;
+            //Coordinate aA = new Coordinate(1, 0, 0);
+            //Coordinate bA = new Coordinate(0, 1, 0);
+            //Coordinate cA = new Coordinate(0, 0, 1);
+            //Coordinate tA = new Coordinate(0, 0, 0);
+
+            //if (d1 == 0.0f)
+            //{
+            //    //if normalize square root is 0
+            //    float cosR = (float)Math.Cos(-theta), sinR = (float)Math.Sin(-theta);
+            //    aA = new Coordinate(1, 0, 0);
+            //    bA = new Coordinate(0, (decimal)cosR, (decimal)-sinR);
+            //    cA = new Coordinate(0, (decimal)sinR, (decimal)cosR);
+            //    tA = new Coordinate(0, 0, 0);
+            //}
+            //else
+            //{
+            //    d2 = 1.0f / d1;
+            //    axis.X *= (decimal)d2;
+            //    axis.Y *= (decimal)d2;
+            //    axis.Z *= (decimal)d2;
+            //    float sinT = (float)Math.Sin(theta);
+            //    axis *= (decimal)sinT;
+            //    Quaternion q = new Quaternion(axis, (decimal)(Math.Cos(theta * 0.5f)));
+            //    float x, y, z, w;
+            //    float x2, y2, z2;
+            //    float xx2, yy2, zz2;
+            //    float xy2, xz2, xw2;
+            //    float yz2, yw2, zw2;
+            //    x = (float)q.X; y = (float)q.Y; z = (float)q.Z; w = (float)q.W;
+            //    x2 = 2 * x; y2 = 2 * y; z2 = 2 * z;
+            //    xx2 = x * x2; yy2 = y * y2; zz2 = z * z2;
+            //    xy2 = y * x2; yz2 = z * y2; zw2 = w * z2;
+            //    xz2 = z * x2; yw2 = w * y2;
+            //    xw2 = w * x2;
+
+            //    aA.X = (decimal)(1.0f - yy2 - zz2);
+            //    aA.Y = (decimal)(xy2 - zw2);
+            //    aA.Z = (decimal)(xz2 + yw2);
+
+            //    bA.X = (decimal)(xy2 + zw2);
+            //    bA.Y = (decimal)(1.0f - xx2 - zz2);
+            //    bA.Z = (decimal)(yz2 - xw2);
+
+            //    cA.X = (decimal)(xz2 - yw2);
+            //    cA.Y = (decimal)(yz2 + xw2);
+            //    cA.Z = (decimal)(1.0f - xx2 - yy2);
+
+            //    tA.X = 0; tA.Y = 0; tA.Z = 0;
+            //}
+
+            //sinA = (float)Math.Sin(angle);
+            //cosA = (float)Math.Cos(angle);
+
+
+            ////Set Texture Rotation
+            //Coordinate a = new Coordinate((decimal)cosA, (decimal)-sinA, 0);
+            //Coordinate b = new Coordinate((decimal)sinA, (decimal)cosA, 0);
+            //Coordinate c = new Coordinate(0, 0, (decimal)1.0f);
+            //Coordinate t = new Coordinate(0, 0, 0);
+
+            //UInt32 Axis = DetermineAxis(this.Plane.Normal);
+            ////Note Y is Z and Z is Y
+            //switch (Axis)
+            //{
+            //    case 0:
+            //        Texture.UAxis = new Coordinate(0, (decimal)-cosA, (decimal)sinA);
+            //        Texture.VAxis = new Coordinate(0, (decimal)-sinA, (decimal)-cosA);
+            //        break;
+            //    case 1:
+            //        Texture.UAxis = new Coordinate((decimal)cosA, (decimal)-sinA, 0);
+            //        Texture.VAxis = new Coordinate((decimal)-sinA, (decimal)-cosA, 0);
+            //        break;
+            //    case 2:
+            //        Texture.UAxis = new Coordinate((decimal)cosA, 0, (decimal)sinA);
+            //        Texture.VAxis = new Coordinate((decimal)sinA, 0, (decimal)-cosA);
+            //        break;
+            //}
+            //CalculateTextureCoordinates(false);
+        }
+        
+        public bool IsTextureAlignedToWorld()
+        {
+            return !this.Flags.HasFlag(FaceFlags.TextureLocked);
+        }
+
+        public bool IsTextureAlignedToFace()
+        {
+            return this.Flags.HasFlag(FaceFlags.TextureLocked);
         }
 
         public void AlignTextureWithFace(Face face)
@@ -402,24 +580,25 @@ namespace Chisel.DataStructures.MapObjects
             }
             CalculateTextureCoordinates(true);
         }
-
+        
         /// <summary>
         /// Rotate the texture around the texture normal.
         /// </summary>
         /// <param name="rotate">The rotation angle in degrees</param>
         public void SetTextureRotation(decimal rotate)
         {
+            /*
             var rads = DMath.DegreesToRadians(Texture.Rotation - rotate);
             // Rotate around the texture normal
             var texNorm = Texture.VAxis.Cross(Texture.UAxis).Normalise();
             var transform = new UnitRotate(rads, new Line(Coordinate.Zero, texNorm));
             Texture.UAxis = transform.Transform(Texture.UAxis);
             Texture.VAxis = transform.Transform(Texture.VAxis);
+            */
             Texture.Rotation = rotate;
-
-            CalculateTextureCoordinates(false);
+            
+            //CalculateTextureCoordinates(false);
         }
-
         #endregion
 
         public virtual void UpdateBoundingBox()

--- a/Chisel.Editor/Documents/Document.cs
+++ b/Chisel.Editor/Documents/Document.cs
@@ -114,7 +114,11 @@ namespace Chisel.Editor.Documents
             var items = TextureCollection.GetItems(texList);
             TextureProvider.LoadTextureItems(items);
 
-            Map.PostLoadProcess(GameData, GetTexture, SettingsManager.GetSpecialTextureOpacity);
+            //Map.PostLoadProcess(GameData, GetTexture, SettingsManager.GetSpecialTextureOpacity);
+            Map.PostLoadProcess(GameData,
+                                       GetTexture,
+                                       SettingsManager.GetSpecialTextureOpacity,
+                                       Chisel.Settings.View.GloballyDisableTransparency);
             Map.UpdateDecals(this);
             Map.UpdateModels(this);
             Map.UpdateSprites(this);
@@ -377,7 +381,12 @@ namespace Chisel.Editor.Documents
 
         public void RenderAll()
         {
-            Map.PartialPostLoadProcess(GameData, GetTexture, SettingsManager.GetSpecialTextureOpacity);
+
+            //Map.PartialPostLoadProcess(GameData, GetTexture, SettingsManager.GetSpecialTextureOpacity);
+            Map.PartialPostLoadProcess(GameData, 
+                                       GetTexture,
+                                       SettingsManager.GetSpecialTextureOpacity,
+                                       Chisel.Settings.View.GloballyDisableTransparency);
 
             var decalsUpdated = Map.UpdateDecals(this);
             var modelsUpdated = Map.UpdateModels(this);
@@ -398,7 +407,11 @@ namespace Chisel.Editor.Documents
         public void RenderObjects(IEnumerable<MapObject> objects)
         {
             var objs = objects.ToList();
-            Map.PartialPostLoadProcess(GameData, GetTexture, SettingsManager.GetSpecialTextureOpacity);
+            //Map.PartialPostLoadProcess(GameData, GetTexture, SettingsManager.GetSpecialTextureOpacity);
+            Map.PartialPostLoadProcess(GameData,
+                                       GetTexture,
+                                       SettingsManager.GetSpecialTextureOpacity,
+                                       Chisel.Settings.View.GloballyDisableTransparency);
 
             var decalsUpdated = Map.UpdateDecals(this, objs);
             var modelsUpdated = Map.UpdateModels(this, objs);
@@ -416,7 +429,11 @@ namespace Chisel.Editor.Documents
 
         public void RenderFaces(IEnumerable<Face> faces)
         {
-            Map.PartialPostLoadProcess(GameData, GetTexture, SettingsManager.GetSpecialTextureOpacity);
+            //Map.PartialPostLoadProcess(GameData, GetTexture, SettingsManager.GetSpecialTextureOpacity);
+            Map.PartialPostLoadProcess(GameData,
+                                       GetTexture,
+                                       SettingsManager.GetSpecialTextureOpacity,
+                                       Chisel.Settings.View.GloballyDisableTransparency);
             // No need to update decals or models here: they can only be changed via entity properties
             HelperManager.UpdateCache();
             Renderer.UpdatePartial(faces);

--- a/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.Designer.cs
+++ b/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.Designer.cs
@@ -73,17 +73,17 @@ namespace Chisel.Editor.Tools.TextureTool
             this.RecentTexturesList = new Chisel.Editor.UI.TextureListPanel();
             this.SelectedTexturesList = new Chisel.Editor.UI.TextureListPanel();
             this.gbspGroup = new System.Windows.Forms.GroupBox();
-            this.chkMirror = new System.Windows.Forms.CheckBox();
-            this.chkFullBright = new System.Windows.Forms.CheckBox();
-            this.chkTransparent = new System.Windows.Forms.CheckBox();
-            this.chkSky = new System.Windows.Forms.CheckBox();
-            this.chkLight = new System.Windows.Forms.CheckBox();
-            this.chkFixedHull = new System.Windows.Forms.CheckBox();
-            this.chkGouraud = new System.Windows.Forms.CheckBox();
-            this.chkFlat = new System.Windows.Forms.CheckBox();
-            this.chkTextureLocked = new System.Windows.Forms.CheckBox();
-            this.chkVisible = new System.Windows.Forms.CheckBox();
             this.chkSheet = new System.Windows.Forms.CheckBox();
+            this.chkVisible = new System.Windows.Forms.CheckBox();
+            this.chkTextureLocked = new System.Windows.Forms.CheckBox();
+            this.chkFlat = new System.Windows.Forms.CheckBox();
+            this.chkGouraud = new System.Windows.Forms.CheckBox();
+            this.chkFixedHull = new System.Windows.Forms.CheckBox();
+            this.chkLight = new System.Windows.Forms.CheckBox();
+            this.chkSky = new System.Windows.Forms.CheckBox();
+            this.chkTransparent = new System.Windows.Forms.CheckBox();
+            this.chkFullBright = new System.Windows.Forms.CheckBox();
+            this.chkMirror = new System.Windows.Forms.CheckBox();
             this.groupBox2.SuspendLayout();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.RotationValue)).BeginInit();
@@ -93,6 +93,7 @@ namespace Chisel.Editor.Tools.TextureTool
             ((System.ComponentModel.ISupportInitialize)(this.ShiftXValue)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.ShiftYValue)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.LightmapValue)).BeginInit();
+            this.gbspGroup.SuspendLayout();
             this.SuspendLayout();
             // 
             // label11
@@ -174,6 +175,7 @@ namespace Chisel.Editor.Tools.TextureTool
             // AlignToFaceCheckbox
             // 
             this.AlignToFaceCheckbox.AutoSize = true;
+            this.AlignToFaceCheckbox.Enabled = false;
             this.AlignToFaceCheckbox.Location = new System.Drawing.Point(63, 22);
             this.AlignToFaceCheckbox.Name = "AlignToFaceCheckbox";
             this.AlignToFaceCheckbox.Size = new System.Drawing.Size(50, 17);
@@ -185,6 +187,7 @@ namespace Chisel.Editor.Tools.TextureTool
             // AlignToWorldCheckbox
             // 
             this.AlignToWorldCheckbox.AutoSize = true;
+            this.AlignToWorldCheckbox.Enabled = false;
             this.AlignToWorldCheckbox.Location = new System.Drawing.Point(7, 22);
             this.AlignToWorldCheckbox.Name = "AlignToWorldCheckbox";
             this.AlignToWorldCheckbox.Size = new System.Drawing.Size(54, 17);
@@ -400,7 +403,7 @@ namespace Chisel.Editor.Tools.TextureTool
             this.tableLayoutPanel1.ColumnCount = 3;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 65F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 208F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 212F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.Controls.Add(this.ScaleXValue, 1, 1);
@@ -657,95 +660,15 @@ namespace Chisel.Editor.Tools.TextureTool
             this.gbspGroup.TabStop = false;
             this.gbspGroup.Text = "GBSP";
             // 
-            // chkMirror
+            // chkSheet
             // 
-            this.chkMirror.AutoSize = true;
-            this.chkMirror.Location = new System.Drawing.Point(6, 19);
-            this.chkMirror.Name = "chkMirror";
-            this.chkMirror.Size = new System.Drawing.Size(52, 17);
-            this.chkMirror.TabIndex = 0;
-            this.chkMirror.Text = "Mirror";
-            this.chkMirror.UseVisualStyleBackColor = true;
-            // 
-            // chkFullBright
-            // 
-            this.chkFullBright.AutoSize = true;
-            this.chkFullBright.Location = new System.Drawing.Point(6, 42);
-            this.chkFullBright.Name = "chkFullBright";
-            this.chkFullBright.Size = new System.Drawing.Size(72, 17);
-            this.chkFullBright.TabIndex = 1;
-            this.chkFullBright.Text = "Full Bright";
-            this.chkFullBright.UseVisualStyleBackColor = true;
-            // 
-            // chkTransparent
-            // 
-            this.chkTransparent.AutoSize = true;
-            this.chkTransparent.Location = new System.Drawing.Point(6, 65);
-            this.chkTransparent.Name = "chkTransparent";
-            this.chkTransparent.Size = new System.Drawing.Size(83, 17);
-            this.chkTransparent.TabIndex = 2;
-            this.chkTransparent.Text = "Transparent";
-            this.chkTransparent.UseVisualStyleBackColor = true;
-            // 
-            // chkSky
-            // 
-            this.chkSky.AutoSize = true;
-            this.chkSky.Location = new System.Drawing.Point(95, 65);
-            this.chkSky.Name = "chkSky";
-            this.chkSky.Size = new System.Drawing.Size(44, 17);
-            this.chkSky.TabIndex = 3;
-            this.chkSky.Text = "Sky";
-            this.chkSky.UseVisualStyleBackColor = true;
-            // 
-            // chkLight
-            // 
-            this.chkLight.AutoSize = true;
-            this.chkLight.Location = new System.Drawing.Point(95, 42);
-            this.chkLight.Name = "chkLight";
-            this.chkLight.Size = new System.Drawing.Size(49, 17);
-            this.chkLight.TabIndex = 4;
-            this.chkLight.Text = "Light";
-            this.chkLight.UseVisualStyleBackColor = true;
-            // 
-            // chkFixedHull
-            // 
-            this.chkFixedHull.AutoSize = true;
-            this.chkFixedHull.Location = new System.Drawing.Point(95, 19);
-            this.chkFixedHull.Name = "chkFixedHull";
-            this.chkFixedHull.Size = new System.Drawing.Size(72, 17);
-            this.chkFixedHull.TabIndex = 5;
-            this.chkFixedHull.Text = "Fixed Hull";
-            this.chkFixedHull.UseVisualStyleBackColor = true;
-            // 
-            // chkGouraud
-            // 
-            this.chkGouraud.AutoSize = true;
-            this.chkGouraud.Location = new System.Drawing.Point(173, 19);
-            this.chkGouraud.Name = "chkGouraud";
-            this.chkGouraud.Size = new System.Drawing.Size(67, 17);
-            this.chkGouraud.TabIndex = 6;
-            this.chkGouraud.Text = "Gouraud";
-            this.chkGouraud.UseVisualStyleBackColor = true;
-            // 
-            // chkFlat
-            // 
-            this.chkFlat.AutoSize = true;
-            this.chkFlat.Location = new System.Drawing.Point(173, 42);
-            this.chkFlat.Name = "chkFlat";
-            this.chkFlat.Size = new System.Drawing.Size(43, 17);
-            this.chkFlat.TabIndex = 7;
-            this.chkFlat.Text = "Flat";
-            this.chkFlat.UseVisualStyleBackColor = true;
-            // 
-            // chkTextureLocked
-            // 
-            this.chkTextureLocked.AutoSize = true;
-            this.chkTextureLocked.Location = new System.Drawing.Point(173, 65);
-            this.chkTextureLocked.Name = "chkTextureLocked";
-            this.chkTextureLocked.Size = new System.Drawing.Size(101, 17);
-            this.chkTextureLocked.TabIndex = 8;
-            this.chkTextureLocked.Text = "Texture Locked";
-            this.chkTextureLocked.UseVisualStyleBackColor = true;
+            this.chkSheet.AutoSize = true;
+            this.chkSheet.Location = new System.Drawing.Point(280, 42);
+            this.chkSheet.Name = "chkSheet";
+            this.chkSheet.Size = new System.Drawing.Size(54, 17);
+            this.chkSheet.TabIndex = 10;
+            this.chkSheet.Text = "Sheet";
+            this.chkSheet.UseVisualStyleBackColor = true;
             // 
             // chkVisible
             // 
@@ -757,15 +680,95 @@ namespace Chisel.Editor.Tools.TextureTool
             this.chkVisible.Text = "Visible";
             this.chkVisible.UseVisualStyleBackColor = true;
             // 
-            // chkSheet
+            // chkTextureLocked
             // 
-            this.chkSheet.AutoSize = true;
-            this.chkSheet.Location = new System.Drawing.Point(280, 42);
-            this.chkSheet.Name = "chkSheet";
-            this.chkSheet.Size = new System.Drawing.Size(54, 17);
-            this.chkSheet.TabIndex = 10;
-            this.chkSheet.Text = "Sheet";
-            this.chkSheet.UseVisualStyleBackColor = true;
+            this.chkTextureLocked.AutoSize = true;
+            this.chkTextureLocked.Location = new System.Drawing.Point(173, 65);
+            this.chkTextureLocked.Name = "chkTextureLocked";
+            this.chkTextureLocked.Size = new System.Drawing.Size(101, 17);
+            this.chkTextureLocked.TabIndex = 8;
+            this.chkTextureLocked.Text = "Texture Locked";
+            this.chkTextureLocked.UseVisualStyleBackColor = true;
+            // 
+            // chkFlat
+            // 
+            this.chkFlat.AutoSize = true;
+            this.chkFlat.Location = new System.Drawing.Point(173, 42);
+            this.chkFlat.Name = "chkFlat";
+            this.chkFlat.Size = new System.Drawing.Size(43, 17);
+            this.chkFlat.TabIndex = 7;
+            this.chkFlat.Text = "Flat";
+            this.chkFlat.UseVisualStyleBackColor = true;
+            // 
+            // chkGouraud
+            // 
+            this.chkGouraud.AutoSize = true;
+            this.chkGouraud.Location = new System.Drawing.Point(173, 19);
+            this.chkGouraud.Name = "chkGouraud";
+            this.chkGouraud.Size = new System.Drawing.Size(67, 17);
+            this.chkGouraud.TabIndex = 6;
+            this.chkGouraud.Text = "Gouraud";
+            this.chkGouraud.UseVisualStyleBackColor = true;
+            // 
+            // chkFixedHull
+            // 
+            this.chkFixedHull.AutoSize = true;
+            this.chkFixedHull.Location = new System.Drawing.Point(95, 19);
+            this.chkFixedHull.Name = "chkFixedHull";
+            this.chkFixedHull.Size = new System.Drawing.Size(72, 17);
+            this.chkFixedHull.TabIndex = 5;
+            this.chkFixedHull.Text = "Fixed Hull";
+            this.chkFixedHull.UseVisualStyleBackColor = true;
+            // 
+            // chkLight
+            // 
+            this.chkLight.AutoSize = true;
+            this.chkLight.Location = new System.Drawing.Point(95, 42);
+            this.chkLight.Name = "chkLight";
+            this.chkLight.Size = new System.Drawing.Size(49, 17);
+            this.chkLight.TabIndex = 4;
+            this.chkLight.Text = "Light";
+            this.chkLight.UseVisualStyleBackColor = true;
+            // 
+            // chkSky
+            // 
+            this.chkSky.AutoSize = true;
+            this.chkSky.Location = new System.Drawing.Point(95, 65);
+            this.chkSky.Name = "chkSky";
+            this.chkSky.Size = new System.Drawing.Size(44, 17);
+            this.chkSky.TabIndex = 3;
+            this.chkSky.Text = "Sky";
+            this.chkSky.UseVisualStyleBackColor = true;
+            // 
+            // chkTransparent
+            // 
+            this.chkTransparent.AutoSize = true;
+            this.chkTransparent.Location = new System.Drawing.Point(6, 65);
+            this.chkTransparent.Name = "chkTransparent";
+            this.chkTransparent.Size = new System.Drawing.Size(83, 17);
+            this.chkTransparent.TabIndex = 2;
+            this.chkTransparent.Text = "Transparent";
+            this.chkTransparent.UseVisualStyleBackColor = true;
+            // 
+            // chkFullBright
+            // 
+            this.chkFullBright.AutoSize = true;
+            this.chkFullBright.Location = new System.Drawing.Point(6, 42);
+            this.chkFullBright.Name = "chkFullBright";
+            this.chkFullBright.Size = new System.Drawing.Size(72, 17);
+            this.chkFullBright.TabIndex = 1;
+            this.chkFullBright.Text = "Full Bright";
+            this.chkFullBright.UseVisualStyleBackColor = true;
+            // 
+            // chkMirror
+            // 
+            this.chkMirror.AutoSize = true;
+            this.chkMirror.Location = new System.Drawing.Point(6, 19);
+            this.chkMirror.Name = "chkMirror";
+            this.chkMirror.Size = new System.Drawing.Size(52, 17);
+            this.chkMirror.TabIndex = 0;
+            this.chkMirror.Text = "Mirror";
+            this.chkMirror.UseVisualStyleBackColor = true;
             // 
             // TextureApplicationForm
             // 

--- a/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.cs
+++ b/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.cs
@@ -446,7 +446,32 @@ namespace Chisel.Editor.Tools.TextureTool
             var flag = (FaceFlags)checkbox.Tag;
 
             var faces = Document.Selection.GetSelectedFaces().ToList();
-            faces.ForEach((x) => { if (checkbox.Checked) { x.Flags |= flag; } else { x.Flags ^= flag; } });
+            faces.ForEach((x) => 
+            {
+                if (checkbox.Checked){
+                    x.Flags |= flag;
+                } else {
+                    x.Flags ^= flag;
+                }
+            });
+
+            if (flag == FaceFlags.TextureLocked)
+            {
+                faces.ForEach((x) =>
+                {
+                    if (checkbox.Checked)
+                    {
+                        OnTextureAlign(TextureTool.AlignMode.Face);
+                    }
+                    else
+                    {
+                        OnTextureAlign(TextureTool.AlignMode.World);
+                    }
+                });
+            }
+            if (flag == FaceFlags.Mirror) { this.PropertiesChanged(); }
+            if (flag == FaceFlags.Transparent) { this.PropertiesChanged(); }
+            
         }
 
         private void ScaleXValueChanged(object sender, EventArgs e)
@@ -546,12 +571,12 @@ namespace Chisel.Editor.Tools.TextureTool
 
         private void AlignToWorldClicked(object sender, EventArgs e)
         {
-            OnTextureAlign(TextureTool.AlignMode.World);
+            //OnTextureAlign(TextureTool.AlignMode.World);
         }
 
         private void AlignToFaceClicked(object sender, EventArgs e)
         {
-            OnTextureAlign(TextureTool.AlignMode.Face);
+            //OnTextureAlign(TextureTool.AlignMode.Face);
         }
 
         private void BrowseButtonClicked(object sender, EventArgs e)


### PR DESCRIPTION
-Updated to follow RFedit's model of texture locking. Locked=(WIP, Not working), Unlocked=AlignedToWorld;
	-Removed NCAlignTextureToWorld and NCClosestAxisToNormal from 3dtProvider
	-Introduced World and Face alignment from RFedit face.cpp
		-Note: Current face selection does not 100% match face.cpp calculation due to data-type differences, will be addressed if current solution is buggy
-Enabled Transparency for objects that have the GBSP Transparent object selected
	Calculated as ([Translucency Value]/255)
	Cannot edit the Translucency value in Chisel currently
	Objects tagged as Mirror will not be Transparent even if the Transparent tag is checked and it has a Translucency value
	Implementation not 100% perfect (i.e. unmade brushes in select mode will not render behind them unless made a full brush)
	Tested/Working with OpenGL 1.0 and 2.1
-Entity bounding boxes reduced in size 50%
-Disabled Chisels automatic reduction of texture offsets to keep them small (For debugging)