### PR TITLE
RF Rotation support

### DIFF
--- a/Chisel.DataStructures/MapObjects/Map.cs
+++ b/Chisel.DataStructures/MapObjects/Map.cs
@@ -32,7 +32,7 @@ namespace Chisel.DataStructures.MapObjects
         public bool TextureScalingLock { get; set; }
         public bool Cordon { get; set; }
         public Box CordonBounds { get; set; }
-
+        
         public Map()
         {
             Version = 1;

--- a/Chisel.DataStructures/MapObjects/MapObject.cs
+++ b/Chisel.DataStructures/MapObjects/MapObject.cs
@@ -28,6 +28,9 @@ namespace Chisel.DataStructures.MapObjects
         public Box BoundingBox { get; set; }
         public MetaData MetaData { get; private set; }
 
+        public Coordinate SelCenter { get; set; }
+        public Matrix SelMatrix { get; set; }
+
         protected MapObject(long id)
         {
             ID = id;

--- a/Chisel.DataStructures/MapObjects/TextureReference.cs
+++ b/Chisel.DataStructures/MapObjects/TextureReference.cs
@@ -58,10 +58,13 @@ namespace Chisel.DataStructures.MapObjects
 
         public decimal YShift { get; set; }
         public decimal YScale { get; set; }
-
+        
         public FaceFlags Flags { get; set; }
         public decimal Translucency { get; set; }
         public decimal Opacity { get; set; }
+
+        public Matrix TransformAngleRF { get; set; }
+        public Coordinate PositionRF { get; set; }
 
         public TextureReference()
         {
@@ -74,6 +77,8 @@ namespace Chisel.DataStructures.MapObjects
             XScale = YScale = 1;
             Opacity = 1;
             Translucency = 255;
+            TransformAngleRF = new Matrix();
+            PositionRF = new Coordinate(0, 0, 0);
         }
 
         protected TextureReference(SerializationInfo info, StreamingContext context)
@@ -90,6 +95,7 @@ namespace Chisel.DataStructures.MapObjects
             Flags = (FaceFlags)info.GetInt32("Flags");
             Translucency = info.GetDecimal("Translucency");
             Opacity = info.GetDecimal("Opacity");
+            
         }
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -106,6 +112,9 @@ namespace Chisel.DataStructures.MapObjects
             info.AddValue("Flags", Flags);
             info.AddValue("Translucency", Translucency);
             info.AddValue("Opacity", Opacity);
+
+            info.AddValue("TransformAngleRF", TransformAngleRF);
+            info.AddValue("PositionRF", PositionRF);
         }
 
         public Coordinate GetNormal()

--- a/Chisel.DataStructures/MapObjects/TextureReference.cs
+++ b/Chisel.DataStructures/MapObjects/TextureReference.cs
@@ -95,7 +95,9 @@ namespace Chisel.DataStructures.MapObjects
             Flags = (FaceFlags)info.GetInt32("Flags");
             Translucency = info.GetDecimal("Translucency");
             Opacity = info.GetDecimal("Opacity");
-            
+
+            TransformAngleRF = (Matrix)info.GetValue("TransformAngleRF", typeof(Matrix));
+            PositionRF = (Coordinate)info.GetValue("PositionRF", typeof(Coordinate));
         }
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -137,7 +139,9 @@ namespace Chisel.DataStructures.MapObjects
                 YScale = YScale,
                 Flags = Flags,
                 Translucency = Translucency,
-                Opacity = Opacity
+                Opacity = Opacity,
+                TransformAngleRF = TransformAngleRF,
+                PositionRF = PositionRF
             };
         }
     }

--- a/Chisel.DataStructures/MapObjects/TransformFlags.cs
+++ b/Chisel.DataStructures/MapObjects/TransformFlags.cs
@@ -7,6 +7,12 @@ namespace Chisel.DataStructures.MapObjects
     {
         None = 1 << 0,
         TextureLock = 1 << 1,
-        TextureScalingLock = 1 << 2
+        TextureScalingLock = 1 << 2,
+        RotationX = 1 << 3,
+        RotationY = 1 << 4,
+        RotationZ = 1 << 5,
+        Translate = 1 << 6,
+        Scale = 1 << 7,
+        Move = 2 << 8
     }
 }

--- a/Chisel.Editor/Actions/MapObjects/Operations/CreateEditDelete.cs
+++ b/Chisel.Editor/Actions/MapObjects/Operations/CreateEditDelete.cs
@@ -63,7 +63,7 @@ namespace Chisel.Editor.Actions.MapObjects.Operations
                 // Unclone will reset children, need to reselect them if needed
                 var deselect = obj.FindAll().Where(x => x.IsSelected).ToList();
                 document.Selection.Deselect(deselect);
-
+                
                 EditOperation.PerformOperation(obj);
 
                 var select = obj.FindAll().Where(x => deselect.Any(y => x.ID == y.ID));
@@ -238,7 +238,6 @@ namespace Chisel.Editor.Actions.MapObjects.Operations
             }
             _idsToDelete = null;
 
-            // Edit
             _editObjects.ForEach(x => x.Perform(document));
 
             if (_createdIds.Any() || _deletedObjects.Any())

--- a/Chisel.Editor/Documents/DocumentSubscriptions.cs
+++ b/Chisel.Editor/Documents/DocumentSubscriptions.cs
@@ -603,6 +603,9 @@ namespace Chisel.Editor.Documents
 
                 var value = td.TransformValue;
                 IUnitTransformation transform = null;
+
+                TransformFlags Flags = _document.Map.GetTransformFlags();
+
                 switch (td.TransformType)
                 {
                     case TransformType.Rotate:
@@ -610,19 +613,29 @@ namespace Chisel.Editor.Documents
                         var rot = Matrix.Rotation(Quaternion.EulerAngles(value * DMath.PI / 180)); // Do rotation
                         var fin = Matrix.Translation(box.Center); // Move to final origin
                         transform = new UnitMatrixMult(fin * rot * mov);
+                        //TODO(SVK): //TODO(SVK): Find better implementation than to throw in WorldSpawn
+                        _document.Map.WorldSpawn.SelMatrix = rot;
+                        _document.Map.WorldSpawn.SelCenter = box.Center;
+
+                        if (value.X != 0) Flags |= TransformFlags.RotationX;
+                        if (value.Y != 0) Flags |= TransformFlags.RotationY;
+                        if (value.Z != 0) Flags |= TransformFlags.RotationZ;
+
                         break;
                     case TransformType.Translate:
                         transform = new UnitTranslate(value);
+                        Flags |= TransformFlags.Translate;
                         break;
                     case TransformType.Scale:
                         transform = new UnitScale(value, box.Center);
+                        Flags |= TransformFlags.Scale;
                         break;
                 }
 
                 if (transform == null) return;
 
                 var selected = _document.Selection.GetSelectedParents();
-                _document.PerformAction("Transform selection", new Edit(selected, new TransformEditOperation(transform, _document.Map.GetTransformFlags())));
+                _document.PerformAction("Transform selection", new Edit(selected, new TransformEditOperation(transform, Flags)));
             }
         }
 

--- a/Chisel.Editor/Tools/SelectTool/SelectTool.cs
+++ b/Chisel.Editor/Tools/SelectTool/SelectTool.cs
@@ -933,10 +933,12 @@ namespace Chisel.Editor.Tools.SelectTool
                 var sel = new ChangeSelection(copies.SelectMany(x => x.FindAll()), Document.Selection.GetSelectedObjects());
                 action.Add(sel);
             }
-            else
+            else //NOTE(SVK): This is Move????
             {
                 // Transform the selection
-                cad.Edit(objects, new TransformEditOperation(transform, Document.Map.GetTransformFlags()));
+                TransformFlags Flags = Document.Map.GetTransformFlags();
+                Flags |= TransformFlags.Move;
+                cad.Edit(objects, new TransformEditOperation(transform, Flags));
             }
 
             // Execute the action

--- a/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.cs
+++ b/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.cs
@@ -735,11 +735,6 @@ namespace Chisel.Editor.Tools.TextureTool
             _freeze = false;
             PropertiesChanged();
         }
-
-        private void chkMirror_CheckedChanged_1(object sender, EventArgs e)
-        {
-
-        }
     }
 }
 

--- a/Chisel.Editor/Tools/TextureTool/TextureTool.cs
+++ b/Chisel.Editor/Tools/TextureTool/TextureTool.cs
@@ -154,7 +154,7 @@ namespace Chisel.Editor.Tools.TextureTool
                                       {
                                           face.Texture.Name = texture.Name;
                                           face.Texture.Texture = ti;
-                                          face.CalculateTextureCoordinates(false);
+                                          face.CalculateTextureCoordinates(true);
                                       };
             // When the texture changes, the entire list needs to be regenerated, can't do a partial update.
             Document.PerformAction("Apply texture", new EditFace(Document.Selection.GetSelectedFaces(), action, true));

--- a/Chisel.Providers/Map/3dtProvider.cs
+++ b/Chisel.Providers/Map/3dtProvider.cs
@@ -145,7 +145,7 @@ namespace Chisel.Providers.Map
             
             
             face.Vertices.AddRange(poly.Vertices.Select(x => new Vertex(x, face)));
-            face.InitFaceAngle();
+            
             //NCAlignTextureToWorld(face);
 
             face.Texture.Flags = (FaceFlags)int.Parse(properties["Flags"]);
@@ -168,7 +168,45 @@ namespace Chisel.Providers.Map
             // Skip currently unknown values Transform and Pos
             if (MapVersion > 1.31)
             {
-                rdr.ReadLine(); rdr.ReadLine();
+                texSplit = rdr.ReadLine().Trim().Split(' ','\t');
+                Assert(texSplit.Length == 13);
+                face.Texture.TransformAngleRF = new Matrix();
+
+                /*
+                NOTE(SVK): Keep RF YZ
+                Chisel
+                0-AX  1-AY  2-AZ  3-TX
+                4-BX  5-BY  6-BZ  7-TY
+                8-CX  9-CY 10-CZ 11-TZ
+
+                RF
+                1-AX  2-AY  3-AZ 10-TX
+                4-BX  5-BY  6-BZ 11-TY
+                7-CX  8-CY  9-CZ 12-TZ
+                */
+                //A
+                face.Texture.TransformAngleRF.Values[0] = decimal.Parse(texSplit[1], ns, CultureInfo.InvariantCulture);
+                face.Texture.TransformAngleRF.Values[1] = decimal.Parse(texSplit[2], ns, CultureInfo.InvariantCulture);
+                face.Texture.TransformAngleRF.Values[2] = decimal.Parse(texSplit[3], ns, CultureInfo.InvariantCulture);
+
+                //B
+                face.Texture.TransformAngleRF.Values[4] = decimal.Parse(texSplit[4], ns, CultureInfo.InvariantCulture);
+                face.Texture.TransformAngleRF.Values[5] = decimal.Parse(texSplit[5], ns, CultureInfo.InvariantCulture);
+                face.Texture.TransformAngleRF.Values[6] = decimal.Parse(texSplit[6], ns, CultureInfo.InvariantCulture);
+
+                //C
+                face.Texture.TransformAngleRF.Values[8] = decimal.Parse(texSplit[7], ns, CultureInfo.InvariantCulture);
+                face.Texture.TransformAngleRF.Values[9] = decimal.Parse(texSplit[8], ns, CultureInfo.InvariantCulture);
+                face.Texture.TransformAngleRF.Values[10] = decimal.Parse(texSplit[9], ns, CultureInfo.InvariantCulture);
+
+                //T (transform)
+                face.Texture.TransformAngleRF.Values[3] = decimal.Parse(texSplit[10], ns, CultureInfo.InvariantCulture);
+                face.Texture.TransformAngleRF.Values[7] = decimal.Parse(texSplit[11], ns, CultureInfo.InvariantCulture);
+                face.Texture.TransformAngleRF.Values[11] = decimal.Parse(texSplit[12], ns, CultureInfo.InvariantCulture);
+
+                texSplit = rdr.ReadLine().Trim().Split(' ','\t');
+                face.Texture.PositionRF = Coordinate.Parse(texSplit[1], texSplit[3], texSplit[2]);
+                face.Texture.PositionRF.Y *= -1;
             }
 
             return face;
@@ -436,12 +474,10 @@ namespace Chisel.Providers.Map
 
         private void WriteFace(Face face, StreamWriter wr)
         {
-            //var flags = face.Flags == 0 ? "512" : ((int)face.Flags).ToString();
             WriteProperty("NumPoints", face.Vertices.Count().ToString(), wr, false, 2);
             WriteProperty("Flags", ((int)face.Texture.Flags).ToString(), wr, false, 2);
             WriteProperty("Light", face.Light.ToString(), wr, false, 2);
             WriteProperty("MipMapBias", "1.000000", wr, false, 2);
-            //WriteProperty("Translucency", (face.Texture.Opacity * 255.0f).ToString(), wr, false, 2);
             WriteProperty("Translucency", (face.Texture.Translucency).ToString(), wr, false, 2);
             WriteProperty("Reflectivity", "1.000000", wr, false, 2);
 

--- a/Chisel.Providers/Map/3dtProvider.cs
+++ b/Chisel.Providers/Map/3dtProvider.cs
@@ -502,6 +502,43 @@ namespace Chisel.Providers.Map
             else
                 WriteProperty("LightScale", "1.000000 1.000000", wr, false, 2);
 
+            /*
+                NOTE(SVK): Keep RF YZ
+                Chisel
+                0-AX  1-AY  2-AZ  3-TX
+                4-BX  5-BY  6-BZ  7-TY
+                8-CX  9-CY 10-CZ 11-TZ
+
+                RF
+                1-AX  2-AY  3-AZ 10-TX
+                4-BX  5-BY  6-BZ 11-TY
+                7-CX  8-CY  9-CZ 12-TZ
+            */
+            WriteProperty("Transform",
+                face.Texture.TransformAngleRF.Values[0].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                face.Texture.TransformAngleRF.Values[1].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                face.Texture.TransformAngleRF.Values[2].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+
+                face.Texture.TransformAngleRF.Values[4].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                face.Texture.TransformAngleRF.Values[5].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                face.Texture.TransformAngleRF.Values[6].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+
+                face.Texture.TransformAngleRF.Values[8].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                face.Texture.TransformAngleRF.Values[9].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                face.Texture.TransformAngleRF.Values[10].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+
+                face.Texture.TransformAngleRF.Values[3].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                face.Texture.TransformAngleRF.Values[7].ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                face.Texture.TransformAngleRF.Values[11].ToString("0.000000", CultureInfo.InvariantCulture), wr, false, 1);
+            //X,-Z,Y
+            // ->
+            //X,Y,-Z
+            decimal Temp = -face.Texture.PositionRF.Y;
+            WriteProperty("Pos",
+                face.Texture.PositionRF.X.ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                face.Texture.PositionRF.Z.ToString("0.000000", CultureInfo.InvariantCulture) + " " +
+                Temp.ToString("0.000000", CultureInfo.InvariantCulture), wr, false, 1);
+
             //3DT Version 1.32+ stated the following..
             //Version 1.32 11/04/99 - Brian - Face Info save out Base Vec for Tex Lock
             //Version 1.33 08/15/03 - QoD - Added ActorsDirectory, PawnIniPath; TexRotation is saved as float
@@ -645,7 +682,8 @@ namespace Chisel.Providers.Map
         }
         private void WriteMapStats(Dictionary<string, string> stats, List<Solid> solids, List<Entity> entities, DataStructures.MapObjects.Map map, StreamWriter wr)
         {
-            WriteProperty("3dtVersion", "1.31", wr);
+            //WriteProperty("3dtVersion", "1.31", wr);
+            WriteProperty("3dtVersion", "1.32", wr);
 
             //The count on the Visgroups is off by 1 because it is counting Auto. We do not use Auto in 3DT or RFEdit.
             var NumGroups = (map.Visgroups.Count() - 1).ToString();

--- a/Chisel.Providers/Map/VmfProvider.cs
+++ b/Chisel.Providers/Map/VmfProvider.cs
@@ -177,7 +177,9 @@ namespace Chisel.Providers.Map
             ret.Texture.YShift = vaxis.Item2;
             ret.Texture.YScale = vaxis.Item3;
             ret.Texture.Rotation = side.PropertyDecimal("rotation");
+            ret.Texture.Flags = (FaceFlags)side.PropertyInteger("flags");
             ret.Plane = side.PropertyPlane("plane");
+            
 
             var verts = side.Children.FirstOrDefault(x => x.Name == "vertex");
             if (verts != null)
@@ -204,6 +206,7 @@ namespace Chisel.Providers.Map
             ret["uaxis"] = String.Format(CultureInfo.InvariantCulture, "[{0} {1}] {2}", FormatCoordinate(face.Texture.UAxis), face.Texture.XShift, face.Texture.XScale);
             ret["vaxis"] = String.Format(CultureInfo.InvariantCulture, "[{0} {1}] {2}", FormatCoordinate(face.Texture.VAxis), face.Texture.YShift, face.Texture.YScale);
             ret["rotation"] = face.Texture.Rotation.ToString(CultureInfo.InvariantCulture);
+            ret["flags"] = ((int)face.Texture.Flags).ToString();
             // ret["lightmapscale"]
             // ret["smoothing_groups"]
 


### PR DESCRIPTION
Chisel now uses RF model for rotation.
-Currently SelectionTool Manipulation Mode rotates (i.e. rotate with mouse) not yet supported.
-Issues with RF rotation model will manifest in rotations in Chisel.
--These issues will persist until vertex uv enhancements in intermediate file and GBSP compile program are enhanced.
-Chisel will output texture transforms and Position data. 1.3.2