### PR TITLE
Solid Flag rendering types

### DIFF
--- a/Chisel.DataStructures/MapObjects/Face.cs
+++ b/Chisel.DataStructures/MapObjects/Face.cs
@@ -32,8 +32,8 @@ namespace Chisel.DataStructures.MapObjects
 
         public Box BoundingBox { get; set; }
         
-        public Color RenderHighlightColor { get; set; }
-        public Color RenderWireframeHighlightColor { get; set; }
+        public Color HighlightColor { get; set; }
+        public Color WireframeColor { get; set; }
 
         public Face(long id)
         {
@@ -661,12 +661,17 @@ namespace Chisel.DataStructures.MapObjects
         }
         #endregion
 
-        public void SetHighlights()
+        public void SetHighlights(SolidFlags s = 0)
         {
-            if (Texture.Flags.HasFlag(FaceFlags.FullBright)) RenderHighlightColor = Color.FromArgb(255, 255, 255, (int)(0.5 * 255));
-            else if (Texture.Flags.HasFlag(FaceFlags.Sky)) RenderHighlightColor = Color.FromArgb(255, 0, 255, 255);
-            else if (Texture.Flags.HasFlag(FaceFlags.Light)) RenderHighlightColor = Color.FromArgb(255, 0, 0, 255);
-            else RenderHighlightColor = new Color();
+            if (Texture.Flags.HasFlag(FaceFlags.FullBright)) HighlightColor = Color.FromArgb(255, 255, 255, (int)(0.5 * 255));
+            else if (Texture.Flags.HasFlag(FaceFlags.Sky)) HighlightColor = Color.FromArgb(255, 0, 255, 255);
+            else if (Texture.Flags.HasFlag(FaceFlags.Light)) HighlightColor = Color.FromArgb(255, 0, 0, 255);
+            else HighlightColor = new Color();
+
+            if (s.HasFlag(SolidFlags.hint)) WireframeColor = Color.FromArgb(255, 0, 255, 0); //Green
+            else if (s.HasFlag(SolidFlags.clip)) WireframeColor = Color.FromArgb(255, (int)(0.5 * 255), 0, 255); //Purple
+            else if (s.HasFlag(SolidFlags.detail)) WireframeColor = Color.FromArgb(255, 255, (int)(0.5 * 255), 0); //Orange?
+            else WireframeColor = new Color();
         }
 
         public virtual void UpdateBoundingBox()

--- a/Chisel.DataStructures/MapObjects/Solid.cs
+++ b/Chisel.DataStructures/MapObjects/Solid.cs
@@ -142,6 +142,11 @@ namespace Chisel.DataStructures.MapObjects
 
         }
 
+        public void SetHighlights()
+        {
+            Faces.ForEach(f => f.SetHighlights(Flags));
+        }
+
         /// <summary>
         /// Returns the intersection point closest to the start of the line.
         /// </summary>

--- a/Chisel.Editor/Rendering/Arrays/MapObjectArray.cs
+++ b/Chisel.Editor/Rendering/Arrays/MapObjectArray.cs
@@ -194,15 +194,28 @@ namespace Chisel.Editor.Rendering.Arrays
                   g = face.Colour.G / 255f,
                   b = face.Colour.B / 255f,
                   a = (float)face.Texture.Opacity;
-            
-            float r2 = face.RenderHighlightColor.R / 255f,
-                  g2 = face.RenderHighlightColor.G / 255f,
-                  b2 = face.RenderHighlightColor.B / 255f,
-                  a2 = face.RenderHighlightColor.A / 255f;
-            if ((r2 == 0 && g2 == 0 & b2 == 0 && a2 == 0) || Chisel.Settings.View.DisableGBSPFlagHighlights)
+
+            float r2, g2, b2, a2;
+            r2 = g2 = b2 = a2 = 1.0f;
+            if (!face.HighlightColor.IsEmpty && !Chisel.Settings.View.DisableGBSPFlagHighlights)
             {
-                r2 = g2 = b2 = a2 = 1.0f;
+                r2 = face.HighlightColor.R / 255f;
+                g2 = face.HighlightColor.G / 255f;
+                b2 = face.HighlightColor.B / 255f;
+                a2 = face.HighlightColor.A / 255f;
             }
+
+            float r3, g3, b3, a3, RenderWireframe = 0;
+            r3 = g3 = b3 = a3 = 1.0f;
+            if (!face.WireframeColor.IsEmpty && !Chisel.Settings.View.DisableGBSPFlagHighlights)
+            {
+                r3 = face.WireframeColor.R / 255f;
+                g3 = face.WireframeColor.G / 255f;
+                b3 = face.WireframeColor.B / 255f;
+                a3 = face.WireframeColor.A / 255f;
+                RenderWireframe = 1;
+            }
+
             return face.GetIndexedVertices().Select(vert => new MapObjectVertex
             {
                 Position = new Vector3((float)vert.Location.DX, (float)vert.Location.DY, (float)vert.Location.DZ),
@@ -210,7 +223,9 @@ namespace Chisel.Editor.Rendering.Arrays
                 Texture = new Vector2((float)vert.TextureU, (float)vert.TextureV),
                 Colour = new Color4(r, g, b, a),
                 IsSelected = face.IsSelected || (face.Parent != null && face.Parent.IsSelected) ? 1 : 0,
-                HighlightColor = new Color4(r2, g2, b2, a2)
+                HighlightColor = new Color4(r2, g2, b2, a2),
+                HasWireframe = RenderWireframe,
+                WireframeColor = new Color4(r3, g3, b3, a3)
             });
         }
     }

--- a/Chisel.Editor/Rendering/Arrays/MapObjectVertex.cs
+++ b/Chisel.Editor/Rendering/Arrays/MapObjectVertex.cs
@@ -11,5 +11,7 @@ namespace Chisel.Editor.Rendering.Arrays
         public Color4 Colour;
         public float IsSelected;
         public Color4 HighlightColor;
+        public float HasWireframe;
+        public Color4 WireframeColor;
     }
 }

--- a/Chisel.Editor/Rendering/Shaders/MapObject2D.frag
+++ b/Chisel.Editor/Rendering/Shaders/MapObject2D.frag
@@ -2,6 +2,8 @@
 
 varying vec4 vertexColour;
 varying float vertexSelected;
+varying float vertexhasWireframe;
+varying vec4 vertexHighlightColor;
 
 uniform bool drawSelectedOnly;
 uniform bool drawUnselectedOnly;
@@ -10,9 +12,10 @@ uniform vec4 overrideColour;
 
 void main()
 {
-    if (drawSelectedOnly && vertexSelected <= 0.9) discard;
-    if (drawUnselectedOnly && vertexSelected > 0.9) discard;
+    if ((drawSelectedOnly && vertexSelected <= 0.9) && vertexhasWireframe <= 0.9) discard;
+    if ((drawUnselectedOnly && vertexSelected > 0.9) && vertexhasWireframe <= 0.9) discard;
 
 	gl_FragColor = mix(vertexColour, selectedColour, vertexSelected);
 	if (overrideColour.w > 0) gl_FragColor = overrideColour;
+	if (vertexhasWireframe > 0.9 && vertexSelected <= 0.9) gl_FragColor = vertexHighlightColor;
 }

--- a/Chisel.Editor/Rendering/Shaders/MapObject2D.vert
+++ b/Chisel.Editor/Rendering/Shaders/MapObject2D.vert
@@ -6,8 +6,13 @@ layout(location = 2) in vec2 texture;
 layout(location = 3) in vec4 colour;
 layout(location = 4) in float selected;
 
+layout(location = 6) in float haswireframe;
+layout(location = 7) in vec4 wireframecolor;
+
 varying vec4 vertexColour;
 varying float vertexSelected;
+varying float vertexhasWireframe;
+varying vec4 vertexHighlightColor;
 
 uniform mat4 modelViewMatrix;
 uniform mat4 perspectiveMatrix;
@@ -25,4 +30,6 @@ void main()
 
 	vertexColour = colour;
     vertexSelected = selected;
+	vertexhasWireframe = haswireframe;
+	vertexHighlightColor = wireframecolor;
 }

--- a/Chisel.Editor/Rendering/Shaders/MapObject3D.frag
+++ b/Chisel.Editor/Rendering/Shaders/MapObject3D.frag
@@ -7,6 +7,7 @@ varying float vertexLighting;
 varying vec2 texCoord;
 varying float vertexSelected;
 varying vec4 vertexHighlightColor;
+varying float vertexhasWireframe;
 
 uniform bool isTextured;
 uniform bool isLit;
@@ -17,6 +18,7 @@ uniform sampler2D currentTexture;
 
 void main()
 {
+	if (vertexhasWireframe >= 0.9) discard;
     vec4 outputColor;
 	float lighting = vertexLighting;
 	if (!isLit) lighting = 1;

--- a/Chisel.Editor/Rendering/Shaders/MapObject3D.vert
+++ b/Chisel.Editor/Rendering/Shaders/MapObject3D.vert
@@ -6,6 +6,7 @@ layout(location = 2) in vec2 texture;
 layout(location = 3) in vec4 colour;
 layout(location = 4) in float selected;
 layout(location = 5) in vec4 highlightcolor;
+layout(location = 6) in float haswireframe;
 
 const vec3 lightDirection = normalize(vec3(1, 2, 3));
 const float lightIntensity = 0.5;
@@ -18,6 +19,7 @@ varying vec4 vertexColour;
 varying vec2 texCoord;
 varying float vertexSelected;
 varying vec4 vertexHighlightColor;
+varying float vertexhasWireframe;
 
 uniform mat4 transformation;
 uniform mat4 modelViewMatrix;
@@ -51,4 +53,5 @@ void main()
     texCoord = texture;
     vertexSelected = selected;
 	vertexHighlightColor = highlightcolor;
+	vertexhasWireframe = haswireframe;
 }

--- a/Chisel.Editor/Settings/SettingsForm.cs
+++ b/Chisel.Editor/Settings/SettingsForm.cs
@@ -650,7 +650,7 @@ namespace Chisel.Editor.Settings
             AddSetting(() => Chisel.Settings.View.DisableTextureFiltering, "Disable texture filtering (try this if textures render incorrectly)");
             AddSetting(() => Chisel.Settings.View.ForcePowerOfTwoTextureResizing, "Force non power of two textures to be resized (try this if only 64, 128, 256, 512, etc size textures work)");
             //NOTE(SVK):Settings
-            AddSetting(() => Chisel.Settings.View.DisableGBSPFlagHighlights, "GBSP Flag highlights");
+            AddSetting(() => Chisel.Settings.View.DisableGBSPFlagHighlights, "Disable GBSP Flag highlights");
 
             AddHeading("Center Handles");
             AddSetting(() => Chisel.Settings.Select.DrawCenterHandles, "Render brush center handles");

--- a/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.cs
+++ b/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.cs
@@ -127,7 +127,7 @@ namespace Chisel.Editor.UI.ObjectProperties
                 Document.PerformAction(actionText, ac);
             }
 
-            if (!GBSPMultiple)
+            if (!GBSPMultiple && Objects.All(x => x is Solid))
             {
                 SolidFlags s = (SolidFlags)0;
                 if (chkSolid.Checked) s |= SolidFlags.solid;

--- a/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.cs
+++ b/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.cs
@@ -144,6 +144,7 @@ namespace Chisel.Editor.UI.ObjectProperties
                 for (int x = 0; x < Objects.Count; x++)
                 {
                     ((Solid)Objects[x]).Flags = s;
+                    ((Solid)Objects[x]).SetHighlights();
                 }
 
             }

--- a/Chisel.Providers/Map/3dtProvider.cs
+++ b/Chisel.Providers/Map/3dtProvider.cs
@@ -258,6 +258,7 @@ namespace Chisel.Providers.Map
             ret.MetaData.Set("ModelId", properties["ModelId"]);
             ret.MetaData.Set("HullSize", properties["HullSize"]);
             ret.MetaData.Set("Type", properties["Type"]);
+            ret.SetHighlights();
 
             int group = int.Parse(properties["GroupId"]);
             if (group > 0)


### PR DESCRIPTION
Brush Flag Support item #4 implemented.
Currently: Hint = Green wireframe, Clip = Purple wireframe, Detail = Orange wireframe.  still need to look into what needs to be changed in the renderer for dotted lines.