### PR TITLE
Fix Clip Tool compiler crash

### DIFF
--- a/Chisel.DataStructures/MapObjects/Face.cs
+++ b/Chisel.DataStructures/MapObjects/Face.cs
@@ -19,10 +19,10 @@ namespace Chisel.DataStructures.MapObjects
 
         public bool IsSelected { get; set; }
         public bool IsHidden { get; set; }
-        
-        
+
+
         public int Light { get; set; }
-        
+
         public Coordinate LightScale { get; set; }
 
         public TextureReference Texture { get; set; }
@@ -31,7 +31,7 @@ namespace Chisel.DataStructures.MapObjects
         public Solid Parent { get; set; }
 
         public Box BoundingBox { get; set; }
-        
+
         public Color HighlightColor { get; set; }
         public Color WireframeColor { get; set; }
 
@@ -42,7 +42,7 @@ namespace Chisel.DataStructures.MapObjects
             Vertices = new List<Vertex>();
             IsSelected = false;
         }
-        
+
         protected Face(SerializationInfo info, StreamingContext context)
         {
             ID = info.GetInt64("ID");
@@ -183,7 +183,7 @@ namespace Chisel.DataStructures.MapObjects
             Top,
             Bottom
         }
-        
+
         public virtual void CalculateTextureCoordinates(bool minimizeShiftValues)
         {
             if (minimizeShiftValues) MinimiseTextureShiftValues();
@@ -229,14 +229,14 @@ namespace Chisel.DataStructures.MapObjects
 
                     x = (Texture.XShift - (decimal)uO) / Texture.Texture.Width;
                     y = (Texture.YShift - (decimal)vO) / Texture.Texture.Height;
-                    
+
                     v.TextureU = (v.Location.Dot(uVec) / Texture.Texture.Width) + (x);
                     v.TextureV = (v.Location.Dot(vVec) / Texture.Texture.Height) + (y);
-                    
+
                 }
             }
         }
-        
+
         private Matrix MatrixMultiplyRF(Matrix m1, Matrix m2)
         {
             Matrix r = new Matrix();
@@ -260,20 +260,20 @@ namespace Chisel.DataStructures.MapObjects
             CX2 = m2.Values[8]; CY2 = m2.Values[9]; CZ2 = m2.Values[10];
             TX2 = m2.Values[3]; TY2 = m2.Values[7]; TZ2 = m2.Values[11];
 
-            r.Values[0]  = AX1 * AX2 + AY1 * BX2 + AZ1 * CX2;
-            r.Values[1]  = AX1 * AY2 + AY1 * BY2 + AZ1 * CY2;
-            r.Values[2]  = AX1 * AZ2 + AY1 * BZ2 + AZ1 * CZ2;
+            r.Values[0] = AX1 * AX2 + AY1 * BX2 + AZ1 * CX2;
+            r.Values[1] = AX1 * AY2 + AY1 * BY2 + AZ1 * CY2;
+            r.Values[2] = AX1 * AZ2 + AY1 * BZ2 + AZ1 * CZ2;
 
-            r.Values[4]  = BX1 * AX2 + BY1 * BX2 + BZ1 * CX2;
-            r.Values[5]  = BX1 * AY2 + BY1 * BY2 + BZ1 * CY2;
-            r.Values[6]  = BX1 * AZ2 + BY1 * BZ2 + BZ1 * CZ2;
+            r.Values[4] = BX1 * AX2 + BY1 * BX2 + BZ1 * CX2;
+            r.Values[5] = BX1 * AY2 + BY1 * BY2 + BZ1 * CY2;
+            r.Values[6] = BX1 * AZ2 + BY1 * BZ2 + BZ1 * CZ2;
 
-            r.Values[8]  = CX1 * AX2 + CY1 * BX2 + CZ1 * CX2;
-            r.Values[9]  = CX1 * AY2 + CY1 * BY2 + CZ1 * CY2;
+            r.Values[8] = CX1 * AX2 + CY1 * BX2 + CZ1 * CX2;
+            r.Values[9] = CX1 * AY2 + CY1 * BY2 + CZ1 * CY2;
             r.Values[10] = CX1 * AZ2 + CY1 * BZ2 + CZ1 * CZ2;
 
-            r.Values[3]  = AX1 * TX2 + AY1 * TY2 + AZ1 * TZ2 + TX1;
-            r.Values[7]  = BX1 * TX2 + BY1 * TY2 + BZ1 * TZ2 + TY1;
+            r.Values[3] = AX1 * TX2 + AY1 * TY2 + AZ1 * TZ2 + TX1;
+            r.Values[7] = BX1 * TX2 + BY1 * TY2 + BZ1 * TZ2 + TY1;
             r.Values[11] = CX1 * TX2 + CY1 * TY2 + CZ1 * TZ2 + TX1;
             return r;
         }
@@ -286,8 +286,8 @@ namespace Chisel.DataStructures.MapObjects
             decimal YZ2, YW2, ZW2;    // ...
 
             X2 = 2 * q.X; XX2 = X2 * q.X; XY2 = X2 * q.Y; XZ2 = X2 * q.Z; XW2 = X2 * q.W;
-            Y2 = 2 * q.Y;YY2 = Y2 * q.Y;YZ2 = Y2 * q.Z;YW2 = Y2 * q.W;
-            Z2 = 2 * q.Z;ZZ2 =  Z2 * q.Z;ZW2 = Z2 * q.W;
+            Y2 = 2 * q.Y; YY2 = Y2 * q.Y; YZ2 = Y2 * q.Z; YW2 = Y2 * q.W;
+            Z2 = 2 * q.Z; ZZ2 = Z2 * q.Z; ZW2 = Z2 * q.W;
 
             /*
             0-AX  1-AY  2-AZ
@@ -296,9 +296,9 @@ namespace Chisel.DataStructures.MapObjects
             3-TX  7-TY 11-TZ
             */
 
-            r.Values[0] = 1 - YY2 - ZZ2; r.Values[1] = XY2 - ZW2;      r.Values[2] = XZ2 +YW2;
-            r.Values[4] = XY2 + ZW2;     r.Values[5] = 1 - XX2 - ZZ2;  r.Values[6] = YZ2 - XW2;
-            r.Values[8] = XZ2 - YW2;     r.Values[9] = YZ2 + XW2;     r.Values[10] = 1 - XX2 - YY2;
+            r.Values[0] = 1 - YY2 - ZZ2; r.Values[1] = XY2 - ZW2; r.Values[2] = XZ2 + YW2;
+            r.Values[4] = XY2 + ZW2; r.Values[5] = 1 - XX2 - ZZ2; r.Values[6] = YZ2 - XW2;
+            r.Values[8] = XZ2 - YW2; r.Values[9] = YZ2 + XW2; r.Values[10] = 1 - XX2 - YY2;
             r.Values[3] = r.Values[7] = r.Values[11] = 0;
 
             return r;
@@ -313,7 +313,7 @@ namespace Chisel.DataStructures.MapObjects
             cos = Math.Cos(Rotation);
             sin = Math.Sin(Rotation);
 
-            for(int x = 0; x < 16; x++)
+            for (int x = 0; x < 16; x++)
             {
                 r.Values[x] = 0;
             }
@@ -322,7 +322,7 @@ namespace Chisel.DataStructures.MapObjects
             r.Values[1] = (decimal)-sin;
             r.Values[4] = (decimal)sin;
             r.Values[10] = 1;
-            
+
             return r;
         }
         private Coordinate RotateRF(Matrix m, Coordinate p)
@@ -332,8 +332,8 @@ namespace Chisel.DataStructures.MapObjects
             //8-CX  9-CY 10-CZ 11-TZ
             Coordinate r = new Coordinate(0, 0, 0);
 
-            r.X = (p.X * m.Values[0]) + (p.Y * m.Values[1]) + (p.Z *  m.Values[2]);
-            r.Y = (p.X * m.Values[4]) + (p.Y * m.Values[5]) + (p.Z *  m.Values[6]);
+            r.X = (p.X * m.Values[0]) + (p.Y * m.Values[1]) + (p.Z * m.Values[2]);
+            r.Y = (p.X * m.Values[4]) + (p.Y * m.Values[5]) + (p.Z * m.Values[6]);
             r.Z = (p.X * m.Values[8]) + (p.Y * m.Values[9]) + (p.Z * m.Values[10]);
 
             return r;
@@ -379,7 +379,7 @@ namespace Chisel.DataStructures.MapObjects
         {
             int x = MatrixDirection(m);
             Matrix r = new Matrix();
-            
+
             switch (x)
             {
                 case 1: //x
@@ -401,7 +401,7 @@ namespace Chisel.DataStructures.MapObjects
         private TransformFlags GetTransformFlags(Matrix m)
         {
             TransformFlags f = (TransformFlags)0;
-            
+
             //0-AX  1-AY  2-AZ 3-TX
             //4-BX  5-BY  6-BZ 7-TY
             //8-CX  9-CY 10-CZ 11-TZ
@@ -412,7 +412,7 @@ namespace Chisel.DataStructures.MapObjects
                     Math.Round(m.Values[4], 4) == 0 && Math.Round(m.Values[9], 4) == 0 && Math.Round(m.Values[8], 4) == 0) f |= TransformFlags.Translate;
                 else f |= TransformFlags.Skew;
             }
-            else if (Math.Round(m.Values[1], 4) == 0 && Math.Round(m.Values[2], 4) == 0 && Math.Round(m.Values[6],4) == 0 &&
+            else if (Math.Round(m.Values[1], 4) == 0 && Math.Round(m.Values[2], 4) == 0 && Math.Round(m.Values[6], 4) == 0 &&
                      Math.Round(m.Values[4], 4) == 0 && Math.Round(m.Values[9], 4) == 0 && Math.Round(m.Values[8], 4) == 0)
             {
                 f |= TransformFlags.Translate;
@@ -428,6 +428,7 @@ namespace Chisel.DataStructures.MapObjects
         
         public void InitFaceAngle()
         {
+            
             Plane RFPlane = new Plane(ToRF(Vertices[0].Location), ToRF(Vertices[1].Location), ToRF(Vertices[2].Location));
             Coordinate ax,p2 = RFPlane.Normal, p = RFPlane.Normal.Absolute();
             Matrix r = new Matrix();
@@ -532,15 +533,15 @@ namespace Chisel.DataStructures.MapObjects
             // Y = -Z
             switch (Axis)
             {
-                case 0:
+                case 0: //X
                     Texture.UAxis = new Coordinate(-t.X.X, t.Z.X, -t.Y.X);
                     Texture.VAxis = new Coordinate(-t.X.Y, t.Z.Y, -t.Y.Y);
                     break;
-                case 1:
+                case 1: //Y
                     Texture.UAxis = new Coordinate(t.X.X, -t.Z.X, t.Y.X);
                     Texture.VAxis = new Coordinate(-t.X.Y, t.Z.Y, -t.Y.Y);
                     break;
-                case 2:
+                case 2: //Z
                     Texture.UAxis = new Coordinate(t.X.X, -t.Z.X, t.Y.X);
                     Texture.VAxis = new Coordinate(t.X.Y, -t.Z.Y, t.Y.Y);
                     break;

--- a/Chisel.DataStructures/MapObjects/Solid.cs
+++ b/Chisel.DataStructures/MapObjects/Solid.cs
@@ -224,6 +224,7 @@ namespace Chisel.DataStructures.MapObjects
                     break;
                 }
             }
+            front.Faces.Union(back.Faces).ToList().ForEach(x => x.InitFaceAngle());
             front.Faces.Union(back.Faces).ToList().ForEach(x => x.CalculateTextureCoordinates(true));
 
             return true;

--- a/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.Designer.cs
+++ b/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.Designer.cs
@@ -89,22 +89,31 @@ namespace Chisel.Editor.Tools.TextureTool
             this.btnGBSPAReset = new System.Windows.Forms.Button();
             this.chkGBSPAEnableFlip = new System.Windows.Forms.CheckBox();
             this.label12 = new System.Windows.Forms.Label();
-            this.textBox12 = new System.Windows.Forms.TextBox();
-            this.textBox11 = new System.Windows.Forms.TextBox();
+            this.txtPosZ = new System.Windows.Forms.TextBox();
+            this.txtPosY = new System.Windows.Forms.TextBox();
             this.btnGBSPAFlipU = new System.Windows.Forms.Button();
-            this.textBox10 = new System.Windows.Forms.TextBox();
+            this.txtPosX = new System.Windows.Forms.TextBox();
             this.btnGBSPAFlipV = new System.Windows.Forms.Button();
             this.lblTransform = new System.Windows.Forms.Label();
-            this.textBox9 = new System.Windows.Forms.TextBox();
-            this.textBox8 = new System.Windows.Forms.TextBox();
-            this.textBox7 = new System.Windows.Forms.TextBox();
-            this.textBox6 = new System.Windows.Forms.TextBox();
-            this.textBox5 = new System.Windows.Forms.TextBox();
-            this.textBox4 = new System.Windows.Forms.TextBox();
-            this.textBox3 = new System.Windows.Forms.TextBox();
-            this.textBox2 = new System.Windows.Forms.TextBox();
+            this.txtBZ = new System.Windows.Forms.TextBox();
+            this.txtAZ = new System.Windows.Forms.TextBox();
+            this.txtCZ = new System.Windows.Forms.TextBox();
+            this.txtBY = new System.Windows.Forms.TextBox();
+            this.txtAY = new System.Windows.Forms.TextBox();
+            this.txtCY = new System.Windows.Forms.TextBox();
+            this.txtBX = new System.Windows.Forms.TextBox();
+            this.txtAX = new System.Windows.Forms.TextBox();
             this.chkGBSPAEnableAll = new System.Windows.Forms.CheckBox();
-            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.txtCX = new System.Windows.Forms.TextBox();
+            this.grpTexUV = new System.Windows.Forms.GroupBox();
+            this.label14 = new System.Windows.Forms.Label();
+            this.label13 = new System.Windows.Forms.Label();
+            this.txtVZ = new System.Windows.Forms.TextBox();
+            this.txtUZ = new System.Windows.Forms.TextBox();
+            this.txtVY = new System.Windows.Forms.TextBox();
+            this.txtUY = new System.Windows.Forms.TextBox();
+            this.txtVX = new System.Windows.Forms.TextBox();
+            this.txtUX = new System.Windows.Forms.TextBox();
             this.groupBox2.SuspendLayout();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.RotationValue)).BeginInit();
@@ -117,6 +126,7 @@ namespace Chisel.Editor.Tools.TextureTool
             this.gbspGroup.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.TranslucencyValue)).BeginInit();
             this.grpGBSPAdvanced.SuspendLayout();
+            this.grpTexUV.SuspendLayout();
             this.SuspendLayout();
             // 
             // label11
@@ -426,7 +436,7 @@ namespace Chisel.Editor.Tools.TextureTool
             this.tableLayoutPanel1.ColumnCount = 3;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 65F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 231F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 241F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.Controls.Add(this.ScaleXValue, 1, 1);
@@ -829,23 +839,22 @@ namespace Chisel.Editor.Tools.TextureTool
             this.grpGBSPAdvanced.Controls.Add(this.btnGBSPAReset);
             this.grpGBSPAdvanced.Controls.Add(this.chkGBSPAEnableFlip);
             this.grpGBSPAdvanced.Controls.Add(this.label12);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox12);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox11);
+            this.grpGBSPAdvanced.Controls.Add(this.txtPosZ);
+            this.grpGBSPAdvanced.Controls.Add(this.txtPosY);
             this.grpGBSPAdvanced.Controls.Add(this.btnGBSPAFlipU);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox10);
+            this.grpGBSPAdvanced.Controls.Add(this.txtPosX);
             this.grpGBSPAdvanced.Controls.Add(this.btnGBSPAFlipV);
             this.grpGBSPAdvanced.Controls.Add(this.lblTransform);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox9);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox8);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox7);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox6);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox5);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox4);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox3);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox2);
+            this.grpGBSPAdvanced.Controls.Add(this.txtBZ);
+            this.grpGBSPAdvanced.Controls.Add(this.txtAZ);
+            this.grpGBSPAdvanced.Controls.Add(this.txtCZ);
+            this.grpGBSPAdvanced.Controls.Add(this.txtBY);
+            this.grpGBSPAdvanced.Controls.Add(this.txtAY);
+            this.grpGBSPAdvanced.Controls.Add(this.txtCY);
+            this.grpGBSPAdvanced.Controls.Add(this.txtBX);
+            this.grpGBSPAdvanced.Controls.Add(this.txtAX);
             this.grpGBSPAdvanced.Controls.Add(this.chkGBSPAEnableAll);
-            this.grpGBSPAdvanced.Controls.Add(this.textBox1);
-            this.grpGBSPAdvanced.Enabled = false;
+            this.grpGBSPAdvanced.Controls.Add(this.txtCX);
             this.grpGBSPAdvanced.Location = new System.Drawing.Point(15, 511);
             this.grpGBSPAdvanced.Name = "grpGBSPAdvanced";
             this.grpGBSPAdvanced.Size = new System.Drawing.Size(388, 152);
@@ -862,11 +871,11 @@ namespace Chisel.Editor.Tools.TextureTool
             this.btnGBSPAReset.TabIndex = 18;
             this.btnGBSPAReset.Text = "Reset";
             this.btnGBSPAReset.UseVisualStyleBackColor = true;
+            this.btnGBSPAReset.Click += new System.EventHandler(this.btnGBSPReset_Clicked);
             // 
             // chkGBSPAEnableFlip
             // 
             this.chkGBSPAEnableFlip.AutoSize = true;
-            this.chkGBSPAEnableFlip.Enabled = false;
             this.chkGBSPAEnableFlip.Location = new System.Drawing.Point(226, 96);
             this.chkGBSPAEnableFlip.Name = "chkGBSPAEnableFlip";
             this.chkGBSPAEnableFlip.Size = new System.Drawing.Size(78, 17);
@@ -878,27 +887,27 @@ namespace Chisel.Editor.Tools.TextureTool
             // 
             this.label12.AutoSize = true;
             this.label12.Enabled = false;
-            this.label12.Location = new System.Drawing.Point(203, 52);
+            this.label12.Location = new System.Drawing.Point(187, 52);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(83, 13);
             this.label12.TabIndex = 16;
             this.label12.Text = "Texture Position";
             // 
-            // textBox12
+            // txtPosZ
             // 
-            this.textBox12.Enabled = false;
-            this.textBox12.Location = new System.Drawing.Point(322, 68);
-            this.textBox12.Name = "textBox12";
-            this.textBox12.Size = new System.Drawing.Size(52, 20);
-            this.textBox12.TabIndex = 15;
+            this.txtPosZ.Enabled = false;
+            this.txtPosZ.Location = new System.Drawing.Point(322, 68);
+            this.txtPosZ.Name = "txtPosZ";
+            this.txtPosZ.Size = new System.Drawing.Size(60, 20);
+            this.txtPosZ.TabIndex = 15;
             // 
-            // textBox11
+            // txtPosY
             // 
-            this.textBox11.Enabled = false;
-            this.textBox11.Location = new System.Drawing.Point(264, 68);
-            this.textBox11.Name = "textBox11";
-            this.textBox11.Size = new System.Drawing.Size(52, 20);
-            this.textBox11.TabIndex = 14;
+            this.txtPosY.Enabled = false;
+            this.txtPosY.Location = new System.Drawing.Point(256, 68);
+            this.txtPosY.Name = "txtPosY";
+            this.txtPosY.Size = new System.Drawing.Size(60, 20);
+            this.txtPosY.TabIndex = 14;
             // 
             // btnGBSPAFlipU
             // 
@@ -910,13 +919,13 @@ namespace Chisel.Editor.Tools.TextureTool
             this.btnGBSPAFlipU.Text = "Flip U";
             this.btnGBSPAFlipU.UseVisualStyleBackColor = true;
             // 
-            // textBox10
+            // txtPosX
             // 
-            this.textBox10.Enabled = false;
-            this.textBox10.Location = new System.Drawing.Point(206, 68);
-            this.textBox10.Name = "textBox10";
-            this.textBox10.Size = new System.Drawing.Size(52, 20);
-            this.textBox10.TabIndex = 12;
+            this.txtPosX.Enabled = false;
+            this.txtPosX.Location = new System.Drawing.Point(190, 68);
+            this.txtPosX.Name = "txtPosX";
+            this.txtPosX.Size = new System.Drawing.Size(60, 20);
+            this.txtPosX.TabIndex = 12;
             // 
             // btnGBSPAFlipV
             // 
@@ -938,94 +947,181 @@ namespace Chisel.Editor.Tools.TextureTool
             this.lblTransform.TabIndex = 10;
             this.lblTransform.Text = "Texture Transform Matrix";
             // 
-            // textBox9
+            // txtBZ
             // 
-            this.textBox9.Enabled = false;
-            this.textBox9.Location = new System.Drawing.Point(122, 94);
-            this.textBox9.Name = "textBox9";
-            this.textBox9.Size = new System.Drawing.Size(52, 20);
-            this.textBox9.TabIndex = 9;
+            this.txtBZ.Enabled = false;
+            this.txtBZ.Location = new System.Drawing.Point(122, 94);
+            this.txtBZ.Name = "txtBZ";
+            this.txtBZ.Size = new System.Drawing.Size(52, 20);
+            this.txtBZ.TabIndex = 9;
             // 
-            // textBox8
+            // txtAZ
             // 
-            this.textBox8.Enabled = false;
-            this.textBox8.Location = new System.Drawing.Point(122, 68);
-            this.textBox8.Name = "textBox8";
-            this.textBox8.Size = new System.Drawing.Size(52, 20);
-            this.textBox8.TabIndex = 8;
+            this.txtAZ.Enabled = false;
+            this.txtAZ.Location = new System.Drawing.Point(122, 68);
+            this.txtAZ.Name = "txtAZ";
+            this.txtAZ.Size = new System.Drawing.Size(52, 20);
+            this.txtAZ.TabIndex = 8;
             // 
-            // textBox7
+            // txtCZ
             // 
-            this.textBox7.Enabled = false;
-            this.textBox7.Location = new System.Drawing.Point(122, 120);
-            this.textBox7.Name = "textBox7";
-            this.textBox7.Size = new System.Drawing.Size(52, 20);
-            this.textBox7.TabIndex = 7;
+            this.txtCZ.Enabled = false;
+            this.txtCZ.Location = new System.Drawing.Point(122, 120);
+            this.txtCZ.Name = "txtCZ";
+            this.txtCZ.Size = new System.Drawing.Size(52, 20);
+            this.txtCZ.TabIndex = 7;
             // 
-            // textBox6
+            // txtBY
             // 
-            this.textBox6.Enabled = false;
-            this.textBox6.Location = new System.Drawing.Point(64, 94);
-            this.textBox6.Name = "textBox6";
-            this.textBox6.Size = new System.Drawing.Size(52, 20);
-            this.textBox6.TabIndex = 6;
+            this.txtBY.Enabled = false;
+            this.txtBY.Location = new System.Drawing.Point(64, 94);
+            this.txtBY.Name = "txtBY";
+            this.txtBY.Size = new System.Drawing.Size(52, 20);
+            this.txtBY.TabIndex = 6;
             // 
-            // textBox5
+            // txtAY
             // 
-            this.textBox5.Enabled = false;
-            this.textBox5.Location = new System.Drawing.Point(64, 68);
-            this.textBox5.Name = "textBox5";
-            this.textBox5.Size = new System.Drawing.Size(52, 20);
-            this.textBox5.TabIndex = 5;
+            this.txtAY.Enabled = false;
+            this.txtAY.Location = new System.Drawing.Point(64, 68);
+            this.txtAY.Name = "txtAY";
+            this.txtAY.Size = new System.Drawing.Size(52, 20);
+            this.txtAY.TabIndex = 5;
             // 
-            // textBox4
+            // txtCY
             // 
-            this.textBox4.Enabled = false;
-            this.textBox4.Location = new System.Drawing.Point(64, 120);
-            this.textBox4.Name = "textBox4";
-            this.textBox4.Size = new System.Drawing.Size(52, 20);
-            this.textBox4.TabIndex = 4;
+            this.txtCY.Enabled = false;
+            this.txtCY.Location = new System.Drawing.Point(64, 120);
+            this.txtCY.Name = "txtCY";
+            this.txtCY.Size = new System.Drawing.Size(52, 20);
+            this.txtCY.TabIndex = 4;
             // 
-            // textBox3
+            // txtBX
             // 
-            this.textBox3.Enabled = false;
-            this.textBox3.Location = new System.Drawing.Point(6, 94);
-            this.textBox3.Name = "textBox3";
-            this.textBox3.Size = new System.Drawing.Size(52, 20);
-            this.textBox3.TabIndex = 3;
+            this.txtBX.Enabled = false;
+            this.txtBX.Location = new System.Drawing.Point(6, 94);
+            this.txtBX.Name = "txtBX";
+            this.txtBX.Size = new System.Drawing.Size(52, 20);
+            this.txtBX.TabIndex = 3;
             // 
-            // textBox2
+            // txtAX
             // 
-            this.textBox2.Enabled = false;
-            this.textBox2.Location = new System.Drawing.Point(6, 68);
-            this.textBox2.Name = "textBox2";
-            this.textBox2.Size = new System.Drawing.Size(52, 20);
-            this.textBox2.TabIndex = 2;
+            this.txtAX.Enabled = false;
+            this.txtAX.Location = new System.Drawing.Point(6, 68);
+            this.txtAX.Name = "txtAX";
+            this.txtAX.Size = new System.Drawing.Size(52, 20);
+            this.txtAX.TabIndex = 2;
             // 
             // chkGBSPAEnableAll
             // 
             this.chkGBSPAEnableAll.AutoSize = true;
-            this.chkGBSPAEnableAll.Enabled = false;
             this.chkGBSPAEnableAll.Location = new System.Drawing.Point(6, 19);
             this.chkGBSPAEnableAll.Name = "chkGBSPAEnableAll";
             this.chkGBSPAEnableAll.Size = new System.Drawing.Size(73, 17);
             this.chkGBSPAEnableAll.TabIndex = 1;
             this.chkGBSPAEnableAll.Text = "Enable All";
             this.chkGBSPAEnableAll.UseVisualStyleBackColor = true;
+            this.chkGBSPAEnableAll.CheckedChanged += new System.EventHandler(this.chkGBSPAEnableAll_CheckedChanged);
             // 
-            // textBox1
+            // txtCX
             // 
-            this.textBox1.Enabled = false;
-            this.textBox1.Location = new System.Drawing.Point(6, 120);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(52, 20);
-            this.textBox1.TabIndex = 0;
+            this.txtCX.Enabled = false;
+            this.txtCX.Location = new System.Drawing.Point(6, 120);
+            this.txtCX.Name = "txtCX";
+            this.txtCX.Size = new System.Drawing.Size(52, 20);
+            this.txtCX.TabIndex = 0;
+            // 
+            // grpTexUV
+            // 
+            this.grpTexUV.Controls.Add(this.label14);
+            this.grpTexUV.Controls.Add(this.label13);
+            this.grpTexUV.Controls.Add(this.txtVZ);
+            this.grpTexUV.Controls.Add(this.txtUZ);
+            this.grpTexUV.Controls.Add(this.txtVY);
+            this.grpTexUV.Controls.Add(this.txtUY);
+            this.grpTexUV.Controls.Add(this.txtVX);
+            this.grpTexUV.Controls.Add(this.txtUX);
+            this.grpTexUV.Enabled = false;
+            this.grpTexUV.Location = new System.Drawing.Point(15, 669);
+            this.grpTexUV.Name = "grpTexUV";
+            this.grpTexUV.Size = new System.Drawing.Size(388, 61);
+            this.grpTexUV.TabIndex = 41;
+            this.grpTexUV.TabStop = false;
+            this.grpTexUV.Text = "Texture UV";
+            // 
+            // label14
+            // 
+            this.label14.AutoSize = true;
+            this.label14.Enabled = false;
+            this.label14.Location = new System.Drawing.Point(211, 16);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(68, 13);
+            this.label14.TabIndex = 11;
+            this.label14.Text = "V Coordinate";
+            // 
+            // label13
+            // 
+            this.label13.AutoSize = true;
+            this.label13.Enabled = false;
+            this.label13.Location = new System.Drawing.Point(6, 16);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(69, 13);
+            this.label13.TabIndex = 10;
+            this.label13.Text = "U Coordinate";
+            // 
+            // txtVZ
+            // 
+            this.txtVZ.Enabled = false;
+            this.txtVZ.Location = new System.Drawing.Point(330, 32);
+            this.txtVZ.Name = "txtVZ";
+            this.txtVZ.Size = new System.Drawing.Size(52, 20);
+            this.txtVZ.TabIndex = 9;
+            // 
+            // txtUZ
+            // 
+            this.txtUZ.Enabled = false;
+            this.txtUZ.Location = new System.Drawing.Point(122, 32);
+            this.txtUZ.Name = "txtUZ";
+            this.txtUZ.Size = new System.Drawing.Size(52, 20);
+            this.txtUZ.TabIndex = 8;
+            // 
+            // txtVY
+            // 
+            this.txtVY.Enabled = false;
+            this.txtVY.Location = new System.Drawing.Point(272, 32);
+            this.txtVY.Name = "txtVY";
+            this.txtVY.Size = new System.Drawing.Size(52, 20);
+            this.txtVY.TabIndex = 6;
+            // 
+            // txtUY
+            // 
+            this.txtUY.Enabled = false;
+            this.txtUY.Location = new System.Drawing.Point(64, 32);
+            this.txtUY.Name = "txtUY";
+            this.txtUY.Size = new System.Drawing.Size(52, 20);
+            this.txtUY.TabIndex = 5;
+            // 
+            // txtVX
+            // 
+            this.txtVX.Enabled = false;
+            this.txtVX.Location = new System.Drawing.Point(214, 32);
+            this.txtVX.Name = "txtVX";
+            this.txtVX.Size = new System.Drawing.Size(52, 20);
+            this.txtVX.TabIndex = 3;
+            // 
+            // txtUX
+            // 
+            this.txtUX.Enabled = false;
+            this.txtUX.Location = new System.Drawing.Point(6, 32);
+            this.txtUX.Name = "txtUX";
+            this.txtUX.Size = new System.Drawing.Size(52, 20);
+            this.txtUX.TabIndex = 2;
             // 
             // TextureApplicationForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(417, 675);
+            this.ClientSize = new System.Drawing.Size(417, 732);
+            this.Controls.Add(this.grpTexUV);
             this.Controls.Add(this.grpGBSPAdvanced);
             this.Controls.Add(this.gbspGroup);
             this.Controls.Add(this.HideMaskCheckbox);
@@ -1073,6 +1169,8 @@ namespace Chisel.Editor.Tools.TextureTool
             ((System.ComponentModel.ISupportInitialize)(this.TranslucencyValue)).EndInit();
             this.grpGBSPAdvanced.ResumeLayout(false);
             this.grpGBSPAdvanced.PerformLayout();
+            this.grpTexUV.ResumeLayout(false);
+            this.grpTexUV.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1137,22 +1235,31 @@ namespace Chisel.Editor.Tools.TextureTool
         private System.Windows.Forms.GroupBox grpGBSPAdvanced;
         private System.Windows.Forms.CheckBox chkGBSPAEnableFlip;
         private System.Windows.Forms.Label label12;
-        private System.Windows.Forms.TextBox textBox12;
-        private System.Windows.Forms.TextBox textBox11;
+        private System.Windows.Forms.TextBox txtPosZ;
+        private System.Windows.Forms.TextBox txtPosY;
         private System.Windows.Forms.Button btnGBSPAFlipU;
-        private System.Windows.Forms.TextBox textBox10;
+        private System.Windows.Forms.TextBox txtPosX;
         private System.Windows.Forms.Button btnGBSPAFlipV;
         private System.Windows.Forms.Label lblTransform;
-        private System.Windows.Forms.TextBox textBox9;
-        private System.Windows.Forms.TextBox textBox8;
-        private System.Windows.Forms.TextBox textBox7;
-        private System.Windows.Forms.TextBox textBox6;
-        private System.Windows.Forms.TextBox textBox5;
-        private System.Windows.Forms.TextBox textBox4;
-        private System.Windows.Forms.TextBox textBox3;
-        private System.Windows.Forms.TextBox textBox2;
+        private System.Windows.Forms.TextBox txtBZ;
+        private System.Windows.Forms.TextBox txtAZ;
+        private System.Windows.Forms.TextBox txtCZ;
+        private System.Windows.Forms.TextBox txtBY;
+        private System.Windows.Forms.TextBox txtAY;
+        private System.Windows.Forms.TextBox txtCY;
+        private System.Windows.Forms.TextBox txtBX;
+        private System.Windows.Forms.TextBox txtAX;
         private System.Windows.Forms.CheckBox chkGBSPAEnableAll;
-        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.TextBox txtCX;
         private System.Windows.Forms.Button btnGBSPAReset;
+        private System.Windows.Forms.GroupBox grpTexUV;
+        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.TextBox txtVZ;
+        private System.Windows.Forms.TextBox txtUZ;
+        private System.Windows.Forms.TextBox txtVY;
+        private System.Windows.Forms.TextBox txtUY;
+        private System.Windows.Forms.TextBox txtVX;
+        private System.Windows.Forms.TextBox txtUX;
     }
 }

--- a/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.cs
+++ b/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.cs
@@ -121,6 +121,7 @@ namespace Chisel.Editor.Tools.TextureTool
                 AllGouraud = AllFlat = AllTextureLocked = AllVisible = AllSheet = AllTransparent = true;
                 foreach (var face in faces)
                 {
+
                     if (face.IsTextureAlignedToFace()) NoneAlignedToFace = false;
                     else AllAlignedToFace = false;
                     if (face.IsTextureAlignedToWorld()) NoneAlignedToWorld = false;
@@ -430,7 +431,7 @@ namespace Chisel.Editor.Tools.TextureTool
 
             var faces = Document.Selection.GetSelectedFaces().ToList();
             _currentTextureProperties.Reset(faces);
-
+            
             ScaleXValue.Value = _currentTextureProperties.XScale;
             ScaleYValue.Value = _currentTextureProperties.YScale;
             ShiftXValue.Value = _currentTextureProperties.XShift;
@@ -517,6 +518,47 @@ namespace Chisel.Editor.Tools.TextureTool
                 textures.Add(item);
             }
 
+            chkGBSPAEnableAll.Checked = false;
+            btnGBSPAReset.Enabled = false;
+            if (faces.Count() == 1)
+            {
+                //0-AX  1-AY  2-AZ 3-TX
+                //4-BX  5-BY  6-BZ 7-TY
+                //8-CX  9-CY 10-CZ 11-TZ
+                txtAX.Text = faces[0].Texture.TransformAngleRF[0].ToString();
+                txtAY.Text = faces[0].Texture.TransformAngleRF[1].ToString();
+                txtAZ.Text = faces[0].Texture.TransformAngleRF[2].ToString();
+                
+                txtBX.Text = faces[0].Texture.TransformAngleRF[4].ToString();
+                txtBY.Text = faces[0].Texture.TransformAngleRF[5].ToString();
+                txtBZ.Text = faces[0].Texture.TransformAngleRF[6].ToString();
+                
+                txtCX.Text = faces[0].Texture.TransformAngleRF[8].ToString();
+                txtCY.Text = faces[0].Texture.TransformAngleRF[9].ToString();
+                txtCZ.Text = faces[0].Texture.TransformAngleRF[10].ToString();
+
+                txtPosX.Text = faces[0].Texture.PositionRF.X.ToString();
+                txtPosY.Text = faces[0].Texture.PositionRF.Y.ToString();
+                txtPosZ.Text = faces[0].Texture.PositionRF.Z.ToString();
+
+                txtUX.Text = faces[0].Texture.UAxis.X.ToString();
+                txtUY.Text = faces[0].Texture.UAxis.Y.ToString();
+                txtUZ.Text = faces[0].Texture.UAxis.Z.ToString();
+
+                txtVX.Text = faces[0].Texture.VAxis.X.ToString();
+                txtVY.Text = faces[0].Texture.VAxis.Y.ToString();
+                txtVZ.Text = faces[0].Texture.VAxis.Z.ToString();
+            } else
+            {
+                txtAX.Text = txtBX.Text = txtCX.Text = "";
+                txtAY.Text = txtBY.Text = txtCY.Text = "";
+                txtAZ.Text = txtBZ.Text = txtCZ.Text = "";
+                txtUX.Text = txtUY.Text = txtUZ.Text = "";
+                txtVX.Text = txtVY.Text = txtVZ.Text = "";
+
+
+            }
+
             if (textures.Any())
             {
                 var t = textures[0];
@@ -582,9 +624,7 @@ namespace Chisel.Editor.Tools.TextureTool
             _currentTextureProperties.DifferentRotationValues = false;
             PropertiesChanged();
         }
-
         
-
         private void LightmapValueChanged(object sender, EventArgs e)
         {
             if (_freeze) return;
@@ -845,7 +885,6 @@ namespace Chisel.Editor.Tools.TextureTool
 
             _freeze = false;
         }
-
         private void TranslucencyValueChanged(object sender, EventArgs e)
         {
             if (_freeze) return;
@@ -862,6 +901,31 @@ namespace Chisel.Editor.Tools.TextureTool
 
             _currentTextureProperties.DifferentTranslucencyValues = false;
             PropertiesChanged();
+        }
+
+        private void btnGBSPReset_Clicked(object sender, EventArgs e)
+        {
+            if (_freeze) return;
+            _freeze = true;
+
+            var faces = Document.Selection.GetSelectedFaces().ToList();
+            foreach (Face f in faces)
+            {
+                f.InitFaceAngle();
+            }
+
+            _freeze = false;
+        }
+
+        private void chkGBSPAEnableAll_CheckedChanged(object sender, EventArgs e)
+        {
+            if (_freeze) return;
+            _freeze = true;
+
+            if (chkGBSPAEnableAll.Checked) btnGBSPAReset.Enabled = true;
+            else btnGBSPAReset.Enabled = false;
+
+            _freeze = false;
         }
     }
 }


### PR DESCRIPTION
face angles created through clip tool were not initializing the face angle, using the default of one of the faces not involved in the clip, causing crash.

Also added some info to the texture application tool for texture uv, and angles.