### PR TITLE
Entities 1.0

### DIFF
--- a/Chisel.DataStructures/MapObjects/Entity.cs
+++ b/Chisel.DataStructures/MapObjects/Entity.cs
@@ -79,9 +79,6 @@ namespace Chisel.DataStructures.MapObjects
         {
             if (GameData == null && !Children.Any())
             {
-                //var sub = new Coordinate(-16, -16, -16);
-                //var add = new Coordinate(16, 16, 16);
-                //NOTE(SVK):Smaller entity boxes.
                 var sub = new Coordinate(-8, -8, -8);
                 var add = new Coordinate(8, 8, 8);
                 BoundingBox = new Box(Origin + sub, Origin + add);
@@ -96,9 +93,6 @@ namespace Chisel.DataStructures.MapObjects
             }
             else if (GameData != null && GameData.ClassType == ClassType.Point)
             {
-                //var sub = new Coordinate(-16, -16, -16);
-                //var add = new Coordinate(16, 16, 16);
-                //NOTE(SVK):Smaller entity boxes.
                 var sub = new Coordinate(-8, -8, -8);
                 var add = new Coordinate(8, 8, 8);
                 var behav = GameData.Behaviours.SingleOrDefault(x => x.Name == "size");

--- a/Chisel.DataStructures/MapObjects/EntityData.cs
+++ b/Chisel.DataStructures/MapObjects/EntityData.cs
@@ -28,7 +28,7 @@ namespace Chisel.DataStructures.MapObjects
             Name = gd.Name;
             foreach (var prop in gd.Properties.Where(x => x.Name != "spawnflags"))
             {
-                Properties.Add(new Property {Key = prop.Name, Value = prop.DefaultValue});
+                Properties.Add(new Property { Key = prop.Name, Value = prop.DefaultValue });
             }
         }
 

--- a/Chisel.DataStructures/MapObjects/Face.cs
+++ b/Chisel.DataStructures/MapObjects/Face.cs
@@ -34,6 +34,7 @@ namespace Chisel.DataStructures.MapObjects
 
         public Color HighlightColor { get; set; }
         public Color WireframeColor { get; set; }
+        public bool IgnoreTexture { get; set; }
 
         public Face(long id)
         {
@@ -679,23 +680,32 @@ namespace Chisel.DataStructures.MapObjects
             {
                 WireframeColor = Color.FromArgb(255, 0, 255, 0);//Green
                 Texture.Opacity = 0.2m;
+                IgnoreTexture = true;
             }
             //(s.HasFlag(SolidFlags.clip))
             else if ((s & (UInt32)SolidFlags.clip) != 0)
             {
                 WireframeColor = Color.FromArgb(255, (int)(0.5 * 255), 0, 255);//Purple
                 Texture.Opacity = 0.2m;
+                IgnoreTexture = true;
             }
             //(s.HasFlag(SolidFlags.window) && !Texture.Flags.HasFlag(FaceFlags.Transparent))
             else if (((s & (UInt32)SolidFlags.window) != 0) && !Texture.Flags.HasFlag(FaceFlags.Transparent))
             {
                 WireframeColor = Color.FromArgb(255, 255, (int)(0.5 * 255), 0);//Orange?
                 Texture.Opacity = 0.2m;
+                IgnoreTexture = true;
+            }
+            else if (Parent.MetaData.Get<string>("ModelId") != null && (int.Parse(Parent.MetaData.Get<string>("ModelId")) > 0))
+            {
+                WireframeColor = Color.FromArgb(255, 255, 255, 255);//White
+                IgnoreTexture = false;
             }
             else if (!WireframeColor.IsEmpty)
             {
                 WireframeColor = new Color();
                 SetOpacity();
+                IgnoreTexture = false;
             }
 
         }

--- a/Chisel.DataStructures/MapObjects/Solid.cs
+++ b/Chisel.DataStructures/MapObjects/Solid.cs
@@ -289,3 +289,4 @@ namespace Chisel.DataStructures.MapObjects
         }
     }
 }
+

--- a/Chisel.Editor/Clipboard/ClipboardManager.cs
+++ b/Chisel.Editor/Clipboard/ClipboardManager.cs
@@ -82,7 +82,7 @@ namespace Chisel.Editor.Clipboard
                 try
                 {
                     var gs = GenericStructure.Parse(tr);
-                    return VmfProvider.ExtractCopyStream(gs.FirstOrDefault(), document.Map.IDGenerator);
+                    return VmfProvider.ExtractCopyStream(gs.FirstOrDefault(), document.Map.IDGenerator, document.Map.WorldSpawn.MetaData.Get<Dictionary<string, UInt32>>("EntityCounts"));
                 }
                 catch
                 {

--- a/Chisel.Editor/Editor.cs
+++ b/Chisel.Editor/Editor.cs
@@ -69,7 +69,7 @@ namespace Chisel.Editor
         {
             try
             {
-                var map = MapProvider.GetMapFromFile(fileName);
+                var map = MapProvider.GetMapFromFile(fileName, game.Fgds[0].Path.ToString());
                 DocumentManager.AddAndSwitch(new Document(fileName, map, game));
             }
             catch (ProviderException e)

--- a/Chisel.Editor/Rendering/Arrays/MapObjectArray.cs
+++ b/Chisel.Editor/Rendering/Arrays/MapObjectArray.cs
@@ -225,7 +225,8 @@ namespace Chisel.Editor.Rendering.Arrays
                 IsSelected = face.IsSelected || (face.Parent != null && face.Parent.IsSelected) ? 1 : 0,
                 HighlightColor = new Color4(r2, g2, b2, a2),
                 HasWireframe = RenderWireframe,
-                WireframeColor = new Color4(r3, g3, b3, a3)
+                WireframeColor = new Color4(r3, g3, b3, a3),
+                IgnoreTexture = face.IgnoreTexture ? 1 : 0
             });
         }
     }

--- a/Chisel.Editor/Rendering/Arrays/MapObjectVertex.cs
+++ b/Chisel.Editor/Rendering/Arrays/MapObjectVertex.cs
@@ -13,5 +13,6 @@ namespace Chisel.Editor.Rendering.Arrays
         public Color4 HighlightColor;
         public float HasWireframe;
         public Color4 WireframeColor;
+        public float IgnoreTexture;
     }
 }

--- a/Chisel.Editor/Rendering/Shaders/MapObject2D.vert
+++ b/Chisel.Editor/Rendering/Shaders/MapObject2D.vert
@@ -5,9 +5,10 @@ layout(location = 1) in vec3 normal;
 layout(location = 2) in vec2 texture;
 layout(location = 3) in vec4 colour;
 layout(location = 4) in float selected;
-
+//layout(location = 5) in vec4 highlightcolor;
 layout(location = 6) in float haswireframe;
 layout(location = 7) in vec4 wireframecolor;
+//layout(location = 8) in float ignoretexture;
 
 varying vec4 vertexColour;
 varying float vertexSelected;

--- a/Chisel.Editor/Rendering/Shaders/MapObject3D.frag
+++ b/Chisel.Editor/Rendering/Shaders/MapObject3D.frag
@@ -9,6 +9,7 @@ varying float vertexSelected;
 varying vec4 vertexHighlightColor;
 varying float vertexhasWireframe;
 varying vec4 vertexWireframeColor;
+varying float vertexignoretexture;
 
 uniform bool isTextured;
 uniform bool isLit;
@@ -19,7 +20,6 @@ uniform sampler2D currentTexture;
 
 void main()
 {
-	//if (vertexhasWireframe >= 0.9) discard;
     vec4 outputColor;
 	float lighting = vertexLighting;
 	if (!isLit) lighting = 1;
@@ -33,7 +33,7 @@ void main()
         outputColor = vertexColour * lighting;
     }
 
-	if (vertexhasWireframe >= 0.9){
+	if (vertexhasWireframe >= 0.9 && vertexignoretexture >= 0.9){
 		outputColor = vertexWireframeColor * lighting;
 	}
 

--- a/Chisel.Editor/Rendering/Shaders/MapObject3D.vert
+++ b/Chisel.Editor/Rendering/Shaders/MapObject3D.vert
@@ -8,6 +8,7 @@ layout(location = 4) in float selected;
 layout(location = 5) in vec4 highlightcolor;
 layout(location = 6) in float haswireframe;
 layout(location = 7) in vec4 wireframecolor;
+layout(location = 8) in float ignoretexture;
 
 const vec3 lightDirection = normalize(vec3(1, 2, 3));
 const float lightIntensity = 0.5;
@@ -22,6 +23,7 @@ varying float vertexSelected;
 varying vec4 vertexHighlightColor;
 varying float vertexhasWireframe;
 varying vec4 vertexWireframeColor;
+varying float vertexignoretexture;
 
 uniform mat4 transformation;
 uniform mat4 modelViewMatrix;
@@ -57,4 +59,5 @@ void main()
 	vertexHighlightColor = highlightcolor;
 	vertexhasWireframe = haswireframe;
 	vertexWireframeColor = wireframecolor;
+	vertexignoretexture = ignoretexture;
 }

--- a/Chisel.Editor/Tools/EntityTool.cs
+++ b/Chisel.Editor/Tools/EntityTool.cs
@@ -222,7 +222,7 @@ namespace Chisel.Editor.Tools
 
             var col = gd.Behaviours.Where(x => x.Name == "color").ToArray();
             var colour = col.Any() ? col[0].GetColour(0) : Colour.GetDefaultEntityColour();
-
+            
             var entity = new Entity(Document.Map.IDGenerator.GetNextObjectID())
             {
                 EntityData = new EntityData(gd),
@@ -230,6 +230,17 @@ namespace Chisel.Editor.Tools
                 Colour = colour,
                 Origin = origin
             };
+
+            for (int x = 0; x < entity.EntityData.Properties.Count(); x++)
+            {
+                if (entity.EntityData.Properties[x].Key == "%name%")
+                {
+                    var v = Document.Map.WorldSpawn.MetaData.Get<Dictionary<string, UInt32>>("EntityCounts");
+                    v[gd.Name] += 1;
+                    entity.EntityData.Properties[x].Value = gd.Name + v[gd.Name].ToString();
+                    //entity.EntityData.Properties[x] = Document.Map.WorldSpawn.MetaData.Get<string>["EntityCounts"];
+                }
+            }
 
             if (Select.SelectCreatedEntity) entity.IsSelected = true;
 

--- a/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.Designer.cs
+++ b/Chisel.Editor/Tools/TextureTool/TextureApplicationForm.Designer.cs
@@ -436,7 +436,7 @@ namespace Chisel.Editor.Tools.TextureTool
             this.tableLayoutPanel1.ColumnCount = 3;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 65F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 241F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 242F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.Controls.Add(this.ScaleXValue, 1, 1);

--- a/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.cs
+++ b/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.cs
@@ -127,30 +127,31 @@ namespace Chisel.Editor.UI.ObjectProperties
                 Document.PerformAction(actionText, ac);
             }
 
-            
-            Dictionary<string, UInt32> fCustom = Objects[0].Parent.MetaData.Get<Dictionary<string, UInt32>>("CustomBrushFlags");
-            var keys = fCustom.Keys.ToArray();
-            GBSPMultipleCustom = false;
-            for (int x = 0; x < Objects.Count; x++)
+            if (Objects.All(x => x is Solid))
             {
-                if (CustomFlags.GetItemCheckState(x) == CheckState.Indeterminate) GBSPMultipleCustom = true;
-            }
-            
-            if (Objects.All(x => x is Solid) && !GBSPMultiple && !GBSPMultipleCustom)
-            {
-                UInt32 s = 0;
+                Dictionary<string, UInt32> fCustom = Objects[0].Parent.MetaData.Get<Dictionary<string, UInt32>>("CustomBrushFlags");
+                var keys = fCustom.Keys.ToArray();
+                GBSPMultipleCustom = false;
+                for (int x = 0; x < Objects.Count; x++)
+                {
+                    if (CustomFlags.GetItemCheckState(x) == CheckState.Indeterminate && Objects.All(y => y is Solid)) GBSPMultipleCustom = true;
+                }
 
-                    if (chkSolid.Checked)    s |= (UInt32)SolidFlags.solid;
-                    if (chkWindow.Checked)   s |= (UInt32)SolidFlags.window;
-                    if (chkClip.Checked)     s |= (UInt32)SolidFlags.clip;
-                    if (chkHint.Checked)     s |= (UInt32)SolidFlags.hint;
-                    if (chkEmpty.Checked)    s |= (UInt32)SolidFlags.empty;
+                if (!GBSPMultiple && !GBSPMultipleCustom)
+                {
+                    UInt32 s = 0;
 
-                    if (chkWavy.Checked)     s |= (UInt32)SolidFlags.wavy;
-                    if (chkDetail.Checked)   s |= (UInt32)SolidFlags.detail;
-                    if (chkArea.Checked)     s |= (UInt32)SolidFlags.area;
+                    if (chkSolid.Checked) s |= (UInt32)SolidFlags.solid;
+                    if (chkWindow.Checked) s |= (UInt32)SolidFlags.window;
+                    if (chkClip.Checked) s |= (UInt32)SolidFlags.clip;
+                    if (chkHint.Checked) s |= (UInt32)SolidFlags.hint;
+                    if (chkEmpty.Checked) s |= (UInt32)SolidFlags.empty;
+
+                    if (chkWavy.Checked) s |= (UInt32)SolidFlags.wavy;
+                    if (chkDetail.Checked) s |= (UInt32)SolidFlags.detail;
+                    if (chkArea.Checked) s |= (UInt32)SolidFlags.area;
                     if (chkFlocking.Checked) s |= (UInt32)SolidFlags.flocking;
-                    if (chkSheet.Checked)    s |= (UInt32)SolidFlags.sheet;
+                    if (chkSheet.Checked) s |= (UInt32)SolidFlags.sheet;
 
                     //Custom Flags
                     for (int x = 0; x < Objects.Count; x++)
@@ -162,11 +163,13 @@ namespace Chisel.Editor.UI.ObjectProperties
                         ((Solid)Objects[x]).Flags = s;
                         ((Solid)Objects[x]).SetHighlights();
                     }
+                }
+                else
+                {
+                    MessageBox.Show("Indeterminate checkboxes found, No changes saved.", "Indeterminate", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
             }
-            else
-            {
-                MessageBox.Show("Indeterminate checkboxes found, No changes saved.", "Indeterminate",MessageBoxButtons.OK,MessageBoxIcon.Information);
-            }
+            
             Class.BackColor = Color.White;
         }
 

--- a/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.cs
+++ b/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.cs
@@ -381,8 +381,21 @@ namespace Chisel.Editor.UI.ObjectProperties
             }
 
             _populating = true;
+            if(Objects.Count == 1)
+            {
+                txtModelID.Text = ((Solid)Objects[0]).MetaData.Get<string>("ModelId");
+                txtHullSize.Text = ((Solid)Objects[0]).MetaData.Get<string>("HullSize");
+                txtType.Text = ((Solid)Objects[0]).MetaData.Get<string>("Type");
+                txtName.Text = ((Solid)Objects[0]).ClassName;
+            }
+            else
+            {
+                txtModelID.Text = "";
+                txtHullSize.Text = "";
+                txtType.Text = "";
+                txtName.Text = "";
+            }
             UInt32 f;
-            
             for (int x = 0; x < Objects.Count; x++)
             {
                 f = ((Solid)Objects[x]).Flags;

--- a/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.designer.cs
+++ b/Chisel.Editor/UI/ObjectProperties/ObjectPropertiesDialog.designer.cs
@@ -93,6 +93,8 @@ namespace Chisel.Editor.UI.ObjectProperties
             this.FlagsTab = new System.Windows.Forms.TabPage();
             this.FlagsTable = new System.Windows.Forms.CheckedListBox();
             this.SolidTab = new System.Windows.Forms.TabPage();
+            this.btnMakeSame = new System.Windows.Forms.Button();
+            this.CustomFlags = new System.Windows.Forms.CheckedListBox();
             this.grpGBSPSubType = new System.Windows.Forms.GroupBox();
             this.lblHullThickness = new System.Windows.Forms.Label();
             this.chkSheet = new System.Windows.Forms.CheckBox();
@@ -115,10 +117,17 @@ namespace Chisel.Editor.UI.ObjectProperties
             this.btnCancel = new System.Windows.Forms.Button();
             this.OkButton = new System.Windows.Forms.Button();
             this.button1 = new System.Windows.Forms.Button();
-            this.CustomFlags = new System.Windows.Forms.CheckedListBox();
-            this.btnMakeSame = new System.Windows.Forms.Button();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.lblModelID = new System.Windows.Forms.Label();
+            this.txtModelID = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.txtHullSize = new System.Windows.Forms.TextBox();
+            this.label12 = new System.Windows.Forms.Label();
+            this.txtType = new System.Windows.Forms.TextBox();
             this.Angles = new Chisel.Editor.UI.AngleControl();
             this.VisgroupPanel = new Chisel.Editor.Visgroups.VisgroupPanel();
+            this.label13 = new System.Windows.Forms.Label();
+            this.txtName = new System.Windows.Forms.TextBox();
             this.Tabs.SuspendLayout();
             this.ClassInfoTab.SuspendLayout();
             this.OutputsTab.SuspendLayout();
@@ -130,6 +139,7 @@ namespace Chisel.Editor.UI.ObjectProperties
             this.grpGBSPSubType.SuspendLayout();
             this.grpGBSPType.SuspendLayout();
             this.VisgroupTab.SuspendLayout();
+            this.groupBox2.SuspendLayout();
             this.SuspendLayout();
             // 
             // Tabs
@@ -664,6 +674,7 @@ namespace Chisel.Editor.UI.ObjectProperties
             // 
             // SolidTab
             // 
+            this.SolidTab.Controls.Add(this.groupBox2);
             this.SolidTab.Controls.Add(this.btnMakeSame);
             this.SolidTab.Controls.Add(this.CustomFlags);
             this.SolidTab.Controls.Add(this.grpGBSPSubType);
@@ -675,6 +686,25 @@ namespace Chisel.Editor.UI.ObjectProperties
             this.SolidTab.TabIndex = 5;
             this.SolidTab.Text = "Solid Properties";
             this.SolidTab.UseVisualStyleBackColor = true;
+            // 
+            // btnMakeSame
+            // 
+            this.btnMakeSame.Location = new System.Drawing.Point(384, 346);
+            this.btnMakeSame.Name = "btnMakeSame";
+            this.btnMakeSame.Size = new System.Drawing.Size(131, 23);
+            this.btnMakeSame.TabIndex = 12;
+            this.btnMakeSame.Text = "Make all same type";
+            this.btnMakeSame.UseVisualStyleBackColor = true;
+            this.btnMakeSame.Click += new System.EventHandler(this.MakeSameButtonClicked);
+            // 
+            // CustomFlags
+            // 
+            this.CustomFlags.FormattingEnabled = true;
+            this.CustomFlags.Location = new System.Drawing.Point(384, 6);
+            this.CustomFlags.Name = "CustomFlags";
+            this.CustomFlags.Size = new System.Drawing.Size(284, 334);
+            this.CustomFlags.TabIndex = 11;
+            this.CustomFlags.ThreeDCheckBoxes = true;
             // 
             // grpGBSPSubType
             // 
@@ -688,7 +718,7 @@ namespace Chisel.Editor.UI.ObjectProperties
             this.grpGBSPSubType.Controls.Add(this.chkHollow);
             this.grpGBSPSubType.Location = new System.Drawing.Point(118, 6);
             this.grpGBSPSubType.Name = "grpGBSPSubType";
-            this.grpGBSPSubType.Size = new System.Drawing.Size(260, 364);
+            this.grpGBSPSubType.Size = new System.Drawing.Size(113, 363);
             this.grpGBSPSubType.TabIndex = 3;
             this.grpGBSPSubType.TabStop = false;
             this.grpGBSPSubType.Text = "GBSP Sub Options";
@@ -697,16 +727,16 @@ namespace Chisel.Editor.UI.ObjectProperties
             // 
             this.lblHullThickness.AutoSize = true;
             this.lblHullThickness.Enabled = false;
-            this.lblHullThickness.Location = new System.Drawing.Point(104, 21);
+            this.lblHullThickness.Location = new System.Drawing.Point(6, 21);
             this.lblHullThickness.Name = "lblHullThickness";
-            this.lblHullThickness.Size = new System.Drawing.Size(77, 13);
+            this.lblHullThickness.Size = new System.Drawing.Size(56, 13);
             this.lblHullThickness.TabIndex = 9;
-            this.lblHullThickness.Text = "Hull Thickness";
+            this.lblHullThickness.Text = "Thickness";
             // 
             // chkSheet
             // 
             this.chkSheet.AutoSize = true;
-            this.chkSheet.Location = new System.Drawing.Point(7, 134);
+            this.chkSheet.Location = new System.Drawing.Point(9, 156);
             this.chkSheet.Name = "chkSheet";
             this.chkSheet.Size = new System.Drawing.Size(54, 17);
             this.chkSheet.TabIndex = 6;
@@ -716,7 +746,7 @@ namespace Chisel.Editor.UI.ObjectProperties
             // chkFlocking
             // 
             this.chkFlocking.AutoSize = true;
-            this.chkFlocking.Location = new System.Drawing.Point(7, 111);
+            this.chkFlocking.Location = new System.Drawing.Point(9, 133);
             this.chkFlocking.Name = "chkFlocking";
             this.chkFlocking.Size = new System.Drawing.Size(66, 17);
             this.chkFlocking.TabIndex = 5;
@@ -726,7 +756,7 @@ namespace Chisel.Editor.UI.ObjectProperties
             // chkArea
             // 
             this.chkArea.AutoSize = true;
-            this.chkArea.Location = new System.Drawing.Point(7, 88);
+            this.chkArea.Location = new System.Drawing.Point(9, 110);
             this.chkArea.Name = "chkArea";
             this.chkArea.Size = new System.Drawing.Size(48, 17);
             this.chkArea.TabIndex = 4;
@@ -736,7 +766,7 @@ namespace Chisel.Editor.UI.ObjectProperties
             // chkDetail
             // 
             this.chkDetail.AutoSize = true;
-            this.chkDetail.Location = new System.Drawing.Point(7, 65);
+            this.chkDetail.Location = new System.Drawing.Point(9, 87);
             this.chkDetail.Name = "chkDetail";
             this.chkDetail.Size = new System.Drawing.Size(53, 17);
             this.chkDetail.TabIndex = 3;
@@ -746,7 +776,7 @@ namespace Chisel.Editor.UI.ObjectProperties
             // chkWavy
             // 
             this.chkWavy.AutoSize = true;
-            this.chkWavy.Location = new System.Drawing.Point(7, 42);
+            this.chkWavy.Location = new System.Drawing.Point(9, 64);
             this.chkWavy.Name = "chkWavy";
             this.chkWavy.Size = new System.Drawing.Size(54, 17);
             this.chkWavy.TabIndex = 2;
@@ -756,9 +786,9 @@ namespace Chisel.Editor.UI.ObjectProperties
             // txtHullThickness
             // 
             this.txtHullThickness.Enabled = false;
-            this.txtHullThickness.Location = new System.Drawing.Point(187, 18);
+            this.txtHullThickness.Location = new System.Drawing.Point(68, 18);
             this.txtHullThickness.Name = "txtHullThickness";
-            this.txtHullThickness.Size = new System.Drawing.Size(67, 20);
+            this.txtHullThickness.Size = new System.Drawing.Size(39, 20);
             this.txtHullThickness.TabIndex = 1;
             this.txtHullThickness.Text = "1";
             this.txtHullThickness.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -767,7 +797,7 @@ namespace Chisel.Editor.UI.ObjectProperties
             // 
             this.chkHollow.AutoSize = true;
             this.chkHollow.Enabled = false;
-            this.chkHollow.Location = new System.Drawing.Point(7, 20);
+            this.chkHollow.Location = new System.Drawing.Point(9, 42);
             this.chkHollow.Name = "chkHollow";
             this.chkHollow.Size = new System.Drawing.Size(58, 17);
             this.chkHollow.TabIndex = 0;
@@ -784,7 +814,7 @@ namespace Chisel.Editor.UI.ObjectProperties
             this.grpGBSPType.Controls.Add(this.chkSolid);
             this.grpGBSPType.Location = new System.Drawing.Point(6, 6);
             this.grpGBSPType.Name = "grpGBSPType";
-            this.grpGBSPType.Size = new System.Drawing.Size(106, 364);
+            this.grpGBSPType.Size = new System.Drawing.Size(106, 363);
             this.grpGBSPType.TabIndex = 2;
             this.grpGBSPType.TabStop = false;
             this.grpGBSPType.Text = "GBSP Type";
@@ -918,24 +948,79 @@ namespace Chisel.Editor.UI.ObjectProperties
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.ApplyButtonClicked);
             // 
-            // CustomFlags
+            // groupBox2
             // 
-            this.CustomFlags.FormattingEnabled = true;
-            this.CustomFlags.Location = new System.Drawing.Point(384, 6);
-            this.CustomFlags.Name = "CustomFlags";
-            this.CustomFlags.Size = new System.Drawing.Size(284, 334);
-            this.CustomFlags.TabIndex = 11;
-            this.CustomFlags.ThreeDCheckBoxes = true;
+            this.groupBox2.Controls.Add(this.label13);
+            this.groupBox2.Controls.Add(this.txtName);
+            this.groupBox2.Controls.Add(this.label12);
+            this.groupBox2.Controls.Add(this.txtType);
+            this.groupBox2.Controls.Add(this.label2);
+            this.groupBox2.Controls.Add(this.txtHullSize);
+            this.groupBox2.Controls.Add(this.lblModelID);
+            this.groupBox2.Controls.Add(this.txtModelID);
+            this.groupBox2.Location = new System.Drawing.Point(237, 6);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(122, 363);
+            this.groupBox2.TabIndex = 13;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "GBSP Metadata";
             // 
-            // btnMakeSame
+            // lblModelID
             // 
-            this.btnMakeSame.Location = new System.Drawing.Point(385, 346);
-            this.btnMakeSame.Name = "btnMakeSame";
-            this.btnMakeSame.Size = new System.Drawing.Size(131, 23);
-            this.btnMakeSame.TabIndex = 12;
-            this.btnMakeSame.Text = "Make all same type";
-            this.btnMakeSame.UseVisualStyleBackColor = true;
-            this.btnMakeSame.Click += new System.EventHandler(this.MakeSameButtonClicked);
+            this.lblModelID.AutoSize = true;
+            this.lblModelID.Enabled = false;
+            this.lblModelID.Location = new System.Drawing.Point(6, 21);
+            this.lblModelID.Name = "lblModelID";
+            this.lblModelID.Size = new System.Drawing.Size(50, 13);
+            this.lblModelID.TabIndex = 9;
+            this.lblModelID.Text = "Model ID";
+            // 
+            // txtModelID
+            // 
+            this.txtModelID.Enabled = false;
+            this.txtModelID.Location = new System.Drawing.Point(62, 18);
+            this.txtModelID.Name = "txtModelID";
+            this.txtModelID.Size = new System.Drawing.Size(54, 20);
+            this.txtModelID.TabIndex = 1;
+            this.txtModelID.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Enabled = false;
+            this.label2.Location = new System.Drawing.Point(6, 43);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(48, 13);
+            this.label2.TabIndex = 11;
+            this.label2.Text = "Hull Size";
+            // 
+            // txtHullSize
+            // 
+            this.txtHullSize.Enabled = false;
+            this.txtHullSize.Location = new System.Drawing.Point(62, 40);
+            this.txtHullSize.Name = "txtHullSize";
+            this.txtHullSize.Size = new System.Drawing.Size(54, 20);
+            this.txtHullSize.TabIndex = 10;
+            this.txtHullSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // label12
+            // 
+            this.label12.AutoSize = true;
+            this.label12.Enabled = false;
+            this.label12.Location = new System.Drawing.Point(6, 66);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(31, 13);
+            this.label12.TabIndex = 13;
+            this.label12.Text = "Type";
+            // 
+            // txtType
+            // 
+            this.txtType.Enabled = false;
+            this.txtType.Location = new System.Drawing.Point(62, 63);
+            this.txtType.Name = "txtType";
+            this.txtType.Size = new System.Drawing.Size(54, 20);
+            this.txtType.TabIndex = 12;
+            this.txtType.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // Angles
             // 
@@ -961,6 +1046,25 @@ namespace Chisel.Editor.UI.ObjectProperties
             this.VisgroupPanel.Size = new System.Drawing.Size(662, 319);
             this.VisgroupPanel.SortAutomaticFirst = false;
             this.VisgroupPanel.TabIndex = 2;
+            // 
+            // label13
+            // 
+            this.label13.AutoSize = true;
+            this.label13.Enabled = false;
+            this.label13.Location = new System.Drawing.Point(6, 89);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(35, 13);
+            this.label13.TabIndex = 15;
+            this.label13.Text = "Name";
+            // 
+            // txtName
+            // 
+            this.txtName.Enabled = false;
+            this.txtName.Location = new System.Drawing.Point(62, 86);
+            this.txtName.Name = "txtName";
+            this.txtName.Size = new System.Drawing.Size(54, 20);
+            this.txtName.TabIndex = 14;
+            this.txtName.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // ObjectPropertiesDialog
             // 
@@ -994,6 +1098,8 @@ namespace Chisel.Editor.UI.ObjectProperties
             this.grpGBSPType.ResumeLayout(false);
             this.grpGBSPType.PerformLayout();
             this.VisgroupTab.ResumeLayout(false);
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
             this.ResumeLayout(false);
 
 		}
@@ -1080,5 +1186,14 @@ namespace Chisel.Editor.UI.ObjectProperties
         private System.Windows.Forms.CheckBox chkSolid;
         private System.Windows.Forms.CheckedListBox CustomFlags;
         private System.Windows.Forms.Button btnMakeSame;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.Label lblModelID;
+        private System.Windows.Forms.TextBox txtModelID;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.TextBox txtType;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox txtHullSize;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.TextBox txtName;
     }
 }

--- a/Chisel.Editor/UI/Sidebar/EntitySidebarPanel.cs
+++ b/Chisel.Editor/UI/Sidebar/EntitySidebarPanel.cs
@@ -45,7 +45,7 @@ namespace Chisel.Editor.UI.Sidebar
         }
 
         public GameDataObject GetSelectedEntity()
-        {
+        { 
             return EntityTypeList.SelectedItem as GameDataObject;
         }
     }

--- a/Chisel.Providers/Map/MapFormatProvider.cs
+++ b/Chisel.Providers/Map/MapFormatProvider.cs
@@ -298,7 +298,7 @@ namespace Chisel.Providers.Map
         /// </summary>
         /// <param name="stream">The stream to read from</param>
         /// <returns>The parsed map</returns>
-        protected override DataStructures.MapObjects.Map GetFromStream(Stream stream)
+        protected override DataStructures.MapObjects.Map GetFromStream(Stream stream, string fgd = null)
         {
             using (var reader = new StreamReader(stream))
             {

--- a/Chisel.Providers/Map/MapProvider.cs
+++ b/Chisel.Providers/Map/MapProvider.cs
@@ -29,13 +29,13 @@ namespace Chisel.Providers.Map
             RegisteredProviders.Clear();
         }
 
-        public static DataStructures.MapObjects.Map GetMapFromFile(string fileName)
+        public static DataStructures.MapObjects.Map GetMapFromFile(string fileName, string fgd)
         {
             if (!File.Exists(fileName)) throw new ProviderException("The supplied file doesn't exist.");
             var provider = RegisteredProviders.FirstOrDefault(p => p.IsValidForFileName(fileName));
             if (provider != null)
             {
-                return provider.GetFromFile(fileName);
+                return provider.GetFromFile(fileName, fgd);
             }
             throw new ProviderNotFoundException("No map provider was found for this file.");
         }
@@ -61,11 +61,11 @@ namespace Chisel.Providers.Map
             throw new ProviderNotFoundException("No map provider was found for this file format.");
         }
 
-        protected virtual DataStructures.MapObjects.Map GetFromFile(string filename)
+        protected virtual DataStructures.MapObjects.Map GetFromFile(string filename, string fgd = null)
         {
             using (var strm = new FileStream(filename, FileMode.Open, FileAccess.Read))
             {
-                return GetFromStream(strm);
+                return GetFromStream(strm, fgd);
             }
         }
 
@@ -78,7 +78,7 @@ namespace Chisel.Providers.Map
         }
 
         protected abstract bool IsValidForFileName(string filename);
-        protected abstract DataStructures.MapObjects.Map GetFromStream(Stream stream);
+        protected abstract DataStructures.MapObjects.Map GetFromStream(Stream stream, string fgd = null);
         protected abstract void SaveToStream(Stream stream, DataStructures.MapObjects.Map map);
         protected abstract IEnumerable<MapFeature> GetFormatFeatures();
     }

--- a/Chisel.Providers/Map/ObjProvider.cs
+++ b/Chisel.Providers/Map/ObjProvider.cs
@@ -39,7 +39,7 @@ namespace Chisel.Providers.Map
             return line.StartsWith("#") ? "" : line.Trim();
         }
 
-        protected override DataStructures.MapObjects.Map GetFromStream(Stream stream)
+        protected override DataStructures.MapObjects.Map GetFromStream(Stream stream, string fgd = null)
         {
             using (var reader = new StreamReader(stream))
             {

--- a/Chisel.Providers/Map/VmfProvider.cs
+++ b/Chisel.Providers/Map/VmfProvider.cs
@@ -574,7 +574,7 @@ namespace Chisel.Providers.Map
             }
         }
 
-        protected override DataStructures.MapObjects.Map GetFromStream(Stream stream)
+        protected override DataStructures.MapObjects.Map GetFromStream(Stream stream, string fgd = null)
         {
             using (var reader = new StreamReader(stream))
             {

--- a/Chisel.Providers/Map/VmfProvider.cs
+++ b/Chisel.Providers/Map/VmfProvider.cs
@@ -533,7 +533,7 @@ namespace Chisel.Providers.Map
             return stream;
         }
 
-        public static IEnumerable<MapObject> ExtractCopyStream(GenericStructure gs, IDGenerator generator)
+        public static IEnumerable<MapObject> ExtractCopyStream(GenericStructure gs, IDGenerator generator, Dictionary<string, UInt32> entcnt)
         {
             if (gs == null || gs.Name != "clipboard") return null;
             var dummyGen = new IDGenerator();
@@ -542,6 +542,17 @@ namespace Chisel.Providers.Map
             foreach (var entity in gs.GetChildren("entity"))
             {
                 var ent = ReadEntity(entity, dummyGen);
+
+                for (int x = 0; x < ent.EntityData.Properties.Count(); x++)
+                {
+                    if (ent.EntityData.Properties[x].Key == "%name%")
+                    {
+                        entcnt[ent.ClassName.ToLower()] += 1;
+                        ent.EntityData.Properties[x].Value = ent.ClassName.ToLower() + entcnt[ent.ClassName.ToLower()].ToString();
+                        //entity.EntityData.Properties[x] = Document.Map.WorldSpawn.MetaData.Get<string>["EntityCounts"];
+                    }
+                }
+
                 var groupid = entity.Children.Where(x => x.Name == "editor").Select(x => x.PropertyInteger("groupid")).FirstOrDefault();
                 var entParent = groupid > 0 ? world.Find(x => x.ID == groupid && x is Group).FirstOrDefault() ?? world : world;
                 ent.SetParent(entParent);


### PR DESCRIPTION
Changes:
	Read entities from RF files with FTD data (Complete)
	Write entities read from RF files back to 3dt (Complete)
	Create new entities (complete)
		Entity Tool working
		Copy/Paste working
	Read Custom brush flag enums from FGD data (Complete)
		Will no longer require entity.h file to exist, just preserves as metadata.
	Brushes with motions now highlighted with white WireFrame
		Texture for these brushes will still be rendered
	Added MotionID,Type,HullSize to Solid Brush opens screen - currently viewable only.