### PR TITLE
eOrigin vs prop Origin

### DIFF
--- a/Chisel.Providers/Map/3dtProvider.cs
+++ b/Chisel.Providers/Map/3dtProvider.cs
@@ -387,7 +387,7 @@ namespace Chisel.Providers.Map
 
             int index = FindClassIndex(ClassList, entprops["classname"]);
             Assert(index > -1);
-            var origin = entprops["origin"].ToString().Split(' ');
+            var origin = properties["eOrigin"].ToString().Split(' ');
             DataStructures.GameData.GameDataObject gdo = ClassList[index];
 
             entprops.Remove("classname");


### PR DESCRIPTION
uses eOrigin for Origin point to work around props that may not have Origin prop in 3dt.